### PR TITLE
Store provider name in user session

### DIFF
--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -25,6 +25,9 @@ func (s Session) GetAuthURL() (string, error) {
 
 // Authorize the session with Facebook and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	if s.AccessToken != "" {
+		return s.AccessToken, nil
+	}
 	p := provider.(*Provider)
 	t := &oauth.Transport{Config: p.config}
 	token, err := t.Exchange(params.Get("code"))

--- a/providers/github/session.go
+++ b/providers/github/session.go
@@ -25,6 +25,9 @@ func (s Session) GetAuthURL() (string, error) {
 
 // Authorize the session with Github and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	if s.AccessToken != "" {
+		return s.AccessToken, nil
+	}
 	p := provider.(*Provider)
 	t := &oauth.Transport{Config: p.config}
 	token, err := t.Exchange(params.Get("code"))

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -25,6 +25,9 @@ func (s Session) GetAuthURL() (string, error) {
 
 // Authorize the session with Google+ and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	if s.AccessToken != "" {
+		return s.AccessToken, nil
+	}
 	p := provider.(*Provider)
 	t := &oauth.Transport{Config: p.config}
 	token, err := t.Exchange(params.Get("code"))

--- a/providers/twitter/session.go
+++ b/providers/twitter/session.go
@@ -25,6 +25,9 @@ func (s Session) GetAuthURL() (string, error) {
 
 // Authorize the session with Twitter and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	if s.AccessToken != "" {
+		return s.AccessToken, nil
+	}
 	p := provider.(*Provider)
 	accessToken, err := p.consumer.AuthorizeToken(s.RequestToken, params.Get("oauth_verifier"))
 	if err != nil {


### PR DESCRIPTION
This allows to use `gothic.CompleteUserAuth` to retrieve existing user session without "provider" url parameter
