### PR TITLE
adds really simple Martini + Facebook example

### DIFF
--- a/examples/martini.go
+++ b/examples/martini.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+  "os"
+  "fmt"
+  "net/http"
+
+  "github.com/go-martini/martini"
+  "github.com/markbates/goth"
+  "github.com/markbates/goth/gothic"
+  "github.com/markbates/goth/providers/facebook"
+)
+
+func main() {
+  goth.UseProviders(
+    facebook.New(os.Getenv("FACEBOOK_KEY"), os.Getenv("FACEBOOK_SECRET"), "http://localhost:3000/auth/callback?provider=facebook"),
+  )
+
+  // instantiate Martini
+  m := martini.Classic()
+
+  m.Get("/", func() string {
+    return "Hello world!"
+  })
+
+  m.Get("/auth/callback", func(res http.ResponseWriter, req *http.Request) string {
+    user, err := gothic.CompleteUserAuth(res, req)
+    if err != nil {
+      return "something went wrong"
+    }
+    return fmt.Sprintf("Logged in as %s!", user.Name)
+  })
+
+  m.Get("/auth", gothic.BeginAuthHandler)
+
+  m.Run()
+}


### PR DESCRIPTION
Been playing with getting this working using [martini](https://github.com/go-martini/martini). I had to use regular GET params to set the provider (e.g. `?provider=facebook`) so that the builtin `GetProviderName` works. It would be nice to use [`martini.Params`](http://godoc.org/github.com/go-martini/martini#Params) instead but I haven't quite figured out a nice way to override `GetProviderName` and pass that in (still new to Go).