### PR TITLE
Add support for defining Github scopes to the Github provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Would I love to see more providers? Certainly! Would you love to contribute one?
 4. Commit your changes (git commit -am 'Add some feature')
 5. Push to the branch (git push origin my-new-feature)
 6. Create new Pull Request
+
+To run the tests you must install [testify](https://github.com/stretchr/testify)
+
+    $ go get github.com/stretchr/testify

--- a/providers/github/github_test.go
+++ b/providers/github/github_test.go
@@ -51,6 +51,30 @@ func Test_SessionFromJSON(t *testing.T) {
 	a.Equal(session.AccessToken, "1234567890")
 }
 
+func Test_Scopes(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := githubProvider()
+	a.Equal(0, len(provider.Scopes))
+
+	provider.SetScopes([]string{"repo", "user"})
+	a.Equal(2, len(provider.Scopes))
+
+	session, err := provider.BeginAuth("test-state")
+	s := session.(*github.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "scope=repo,user")
+
+	provider.SetScopes([]string{})
+	a.Equal(0, len(provider.Scopes))
+
+	session, err = provider.BeginAuth("test-state")
+	s = session.(*github.Session)
+	a.NoError(err)
+	a.NotContains(s.AuthURL, "scope=")
+}
+
 func githubProvider() *github.Provider {
 	return github.New(os.Getenv("GITHUB_KEY"), os.Getenv("GITHUB_SECRET"), "/foo")
 }

--- a/providers/github/github_test.go
+++ b/providers/github/github_test.go
@@ -1,6 +1,7 @@
 package github_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -26,17 +27,16 @@ func Test_Implements_Provider(t *testing.T) {
 	a.Implements((*goth.Provider)(nil), githubProvider())
 }
 
-// TODO: Implement a better solution
-// func Test_BeginAuth(t *testing.T) {
-// 	t.Parallel()
-// 	a := assert.New(t)
-//
-// 	provider := githubProvider()
-// 	session, err := provider.BeginAuth()
-// 	s := session.(*github.Session)
-// 	a.NoError(err)
-// 	a.Equal(s.AuthURL, fmt.Sprintf("https://www.github.com/dialog/oauth?client_id=%s&redirect_uri=%%2Ffoo&response_type=code&state=state", provider.ClientKey))
-// }
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := githubProvider()
+	session, err := provider.BeginAuth("state")
+	s := session.(*github.Session)
+	a.NoError(err)
+	a.Equal(s.AuthURL, fmt.Sprintf("https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%%2Ffoo&response_type=code&state=state", provider.ClientKey))
+}
 
 func Test_SessionFromJSON(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
I'm not sure your preference on things like this and your testing style (single assert per test case, etc...).

This is a quick pass implemented to maintain backwards compatibility by extending the existing github provider api to allow for adding scopes before beginning the auth process.

The `New()` function could also be extended to take a `scopes []string` param, but that would break the API for all current users.

Close #20 