### PR TITLE
AppEngine compatibility fix

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -16,7 +16,9 @@ import (
 	"github.com/markbates/goth/providers/linkedin"
 	"github.com/markbates/goth/providers/spotify"
 	"github.com/markbates/goth/providers/twitter"
-	)
+
+	"golang.org/x/net/context"
+)
 
 func main() {
 	goth.UseProviders(
@@ -43,7 +45,7 @@ func main() {
 		// print our state string to the console
 		fmt.Println(gothic.GetState(req))
 
-		user, err := gothic.CompleteUserAuth(res, req)
+		user, err := gothic.CompleteUserAuth(context.TODO(), res, req)
 		if err != nil {
 			fmt.Fprintln(res, err)
 			return

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
+	"golang.org/x/net/context"
 )
 
 // SessionName is the key used to access the session store.
@@ -109,7 +110,7 @@ as either "provider" or ":provider".
 
 See https://github.com/markbates/goth/examples/main.go to see this in action.
 */
-func CompleteUserAuth(res http.ResponseWriter, req *http.Request) (goth.User, error) {
+func CompleteUserAuth(ctx context.Context, res http.ResponseWriter, req *http.Request) (goth.User, error) {
 
 	providerName, err := GetProviderName(req)
 	if err != nil {
@@ -132,7 +133,7 @@ func CompleteUserAuth(res http.ResponseWriter, req *http.Request) (goth.User, er
 		return goth.User{}, err
 	}
 
-	_, err = sess.Authorize(provider, req.URL.Query())
+	_, err = sess.Authorize(ctx, provider, req.URL.Query())
 
 	if err != nil {
 		return goth.User{}, err

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/markbates/goth/gothic"
 	"github.com/markbates/goth/providers/faux"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 type ProviderStore struct {
@@ -92,7 +93,7 @@ func Test_CompleteUserAuth(t *testing.T) {
 	err = session.Save(req, res)
 	a.NoError(err)
 
-	user, err := CompleteUserAuth(res, req)
+	user, err := CompleteUserAuth(context.TODO(), res, req)
 	a.NoError(err)
 
 	a.Equal(user.Name, "Homer Simpson")

--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Facebook.
@@ -23,9 +23,9 @@ func (s Session) GetAuthURL() (string, error) {
 }
 
 // Authorize the session with Facebook and return the access token to be stored for future use.
-func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(ctx, params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/markbates/goth"
+	"golang.org/x/net/context"
 )
 
 // Provider is used only for testing.
@@ -49,7 +50,7 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 func (p *Provider) Debug(debug bool) {}
 
 // Authorize is used only for testing.
-func (p *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (p *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	return "", nil
 }
 

--- a/providers/github/session.go
+++ b/providers/github/session.go
@@ -4,9 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 
-	"golang.org/x/oauth2"
-
 	"github.com/markbates/goth"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Github.
@@ -24,9 +23,9 @@ func (s Session) GetAuthURL() (string, error) {
 }
 
 // Authorize the session with Github and return the access token to be stored for future use.
-func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(ctx, params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Facebook.
@@ -23,9 +23,9 @@ func (s Session) GetAuthURL() (string, error) {
 }
 
 // Authorize the session with Google+ and return the access token to be stored for future use.
-func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(ctx, params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -7,36 +7,33 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"errors"
 	"sort"
 	"strings"
 
 	"github.com/markbates/goth"
 )
 
-
 var (
 	authURL         = "http://www.lastfm.com.br/api/auth"
 	endpointProfile = "http://ws.audioscrobbler.com/2.0/"
 )
-
 
 // New creates a new LastFM provider, and sets up important connection details.
 // You should always call `lastfm.New` to get a new Provider. Never try to craete
 // one manullay.
 func New(clientKey string, secret string, callbackURL string) *Provider {
 	p := &Provider{
-		ClientKey: clientKey,
-		Secret: secret,
+		ClientKey:   clientKey,
+		Secret:      secret,
 		CallbackURL: callbackURL,
 	}
 	return p
 }
-
 
 // Provider is the implementation of `goth.Provider` for accessing LastFM
 type Provider struct {
@@ -66,7 +63,6 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 
 	return session, nil
 }
-
 
 // FetchUser will go to LastFM and access basic information about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
@@ -142,7 +138,7 @@ func (p *Provider) request(sign bool, params map[string]string, result interface
 		urlParams.Add("api_sig", signRequest(p.Secret, params))
 	}
 
-	uri := endpointProfile + "?"+ urlParams.Encode()
+	uri := endpointProfile + "?" + urlParams.Encode()
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", uri, nil)
@@ -165,7 +161,7 @@ func (p *Provider) request(sign bool, params map[string]string, result interface
 		return err
 	}
 
-	base := struct{
+	base := struct {
 		XMLName xml.Name `xml:"lfm"`
 		Status  string   `xml:"status,attr"`
 		Inner   []byte   `xml:",innerxml"`

--- a/providers/lastfm/lastfm_test.go
+++ b/providers/lastfm/lastfm_test.go
@@ -2,9 +2,9 @@ package lastfm
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
-	"net/url"
 
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"

--- a/providers/lastfm/session.go
+++ b/providers/lastfm/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/markbates/goth"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Lastfm.
@@ -23,7 +24,7 @@ func (s Session) GetAuthURL() (string, error) {
 }
 
 // Authorize the session with LastFM and return the access token to be stored for future use.
-func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
 	sess, err := p.GetSession(params.Get("token"))
 	if err != nil {

--- a/providers/linkedin/session.go
+++ b/providers/linkedin/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Linkedin.
@@ -23,9 +23,9 @@ func (s Session) GetAuthURL() (string, error) {
 }
 
 // Authorize the session with Linkedin and return the access token to be stored for future use.
-func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(ctx, params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Spotify.
@@ -25,9 +25,9 @@ func (s Session) GetAuthURL() (string, error) {
 
 // Authorize completes the the authorization with Spotify and returns the access
 // token to be stored for future use.
-func (s Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(ctx, params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/twitter/session.go
+++ b/providers/twitter/session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/markbates/goth"
 	"github.com/mrjones/oauth"
+	"golang.org/x/net/context"
 )
 
 // Session stores data during the auth process with Twitter.
@@ -24,7 +25,7 @@ func (s Session) GetAuthURL() (string, error) {
 }
 
 // Authorize the session with Twitter and return the access token to be stored for future use.
-func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(ctx context.Context, provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
 	accessToken, err := p.consumer.AuthorizeToken(s.RequestToken, params.Get("oauth_verifier"))
 	if err != nil {

--- a/session.go
+++ b/session.go
@@ -1,5 +1,9 @@
 package goth
 
+import (
+	"golang.org/x/net/context"
+)
+
 // Params is used to pass data to sessions for authorization. An existing
 // implementation, and the one most likely to be used, is `url.Values`.
 type Params interface {
@@ -17,5 +21,5 @@ type Session interface {
 	Marshal() string
 	// Authorize should validate the data from the provider and return back an access token
 	// that can be stored for later access to the provider.
-	Authorize(Provider, Params) (string, error)
+	Authorize(context.Context, Provider, Params) (string, error)
 }


### PR DESCRIPTION
Passing a hard-coded `oath2.NoContext` to `oauth2.Config.Exchange` breaks AppEngine compatibility following recent changes to golang/appengine and golang/oauth2 to use context.Context (see: golang.org/x/net/context).
Allowing a context to be passed through `gothic.CompleteUserAuth` / `Session.Authorize` allows a context to be supplied, e.g.:

ctx := appengine.NewContext(req)
user, err := gothic.CompleteUserAuth(ctx, res, req)

Even if not running on AppEngine, the context is still useful to allow providers to handle timeouts / cancellation but context.TODO() can be passed for the time being.