### PR TITLE
twitter: return user with access token secret

### DIFF
--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -89,6 +89,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user.UserID = user.RawData["id_str"].(string)
 	user.Location = user.RawData["location"].(string)
 	user.AccessToken = sess.AccessToken.Token
+	user.AccessTokenSecret = sess.AccessToken.Secret
 	return user, err
 }
 

--- a/user.go
+++ b/user.go
@@ -3,13 +3,14 @@ package goth
 // User contains the information common amongst most OAuth and OAuth2 providers.
 // All of the "raw" datafrom the provider can be found in the `RawData` field.
 type User struct {
-	RawData     map[string]interface{}
-	Email       string
-	Name        string
-	NickName    string
-	Description string
-	UserID      string
-	AvatarURL   string
-	Location    string
-	AccessToken string
+	RawData           map[string]interface{}
+	Email             string
+	Name              string
+	NickName          string
+	Description       string
+	UserID            string
+	AvatarURL         string
+	Location          string
+	AccessToken       string
+	AccessTokenSecret string
 }


### PR DESCRIPTION
We may want to store twitter access_token_secret for later usage, eg: retrieve user timeline.
