### PR TITLE
Add default scope for Twitch if no scope is provided

### DIFF
--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -164,8 +164,12 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 		Scopes: []string{},
 	}
 
-	for _, scope := range scopes {
-		c.Scopes = append(c.Scopes, scope)
+	if len(scopes) > 0 {
+		for _, scope := range scopes {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	} else {
+		c.Scopes = []string{ScopeUserRead}
 	}
 
 	return c


### PR DESCRIPTION
If no scope is provided, the Twitch API will still grant you an access token, but it's useless since there are no permissions belonging to it. That means that despite the fact that you've received an access token from Twitch, you can't access any privileged info with it. What makes it even more confusing is that it won't show a user the usual Oauth permission page (where a user enters their username/password).

This PR adds a default scope of `user_read` when authenticating with Twitch, which is the bare minimum needed to use Twitch as an identity provider.