### PR TITLE
Fix LinkedIn auth flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: false
 go:
   - 1.2
   - 1.3
+  - 1.4
+  - 1.5
   - tip
 
 matrix:

--- a/examples/main.go
+++ b/examples/main.go
@@ -38,19 +38,12 @@ func main() {
 		twitter.New(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
 	)
 
-	// Assign the GetState function variable so we can return the
-	// state string we want to get back at the end of the oauth process.
-	// Only works with facebook and gplus providers.
-	gothic.GetState = func(req *http.Request) string {
-		// Get the state string from the query parameters.
-		return req.URL.Query().Get("state")
-	}
-
 	p := pat.New()
 	p.Get("/auth/{provider}/callback", func(res http.ResponseWriter, req *http.Request) {
 
-		// print our state string to the console
-		fmt.Println(gothic.GetState(req))
+		// print our state string to the console. Ideally, you should verify
+		// that it's the same string as the one you set in `setState`
+		fmt.Println("State: ", gothic.GetState(req))
 
 		user, err := gothic.CompleteUserAuth(res, req)
 		if err != nil {

--- a/examples/main.go
+++ b/examples/main.go
@@ -26,16 +26,16 @@ func main() {
 		twitter.New(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
 		// If you'd like to use authenticate instead of authorize in Twitter provider, use this instead.
 		// twitter.NewAuthenticate(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
-
 		facebook.New(os.Getenv("FACEBOOK_KEY"), os.Getenv("FACEBOOK_SECRET"), "http://localhost:3000/auth/facebook/callback"),
-		gplus.New(os.Getenv("GPLUS_KEY"), os.Getenv("GPLUS_SECRET"), "http://localhost:3000/auth/gplus/callback"),
 		github.New(os.Getenv("GITHUB_KEY"), os.Getenv("GITHUB_SECRET"), "http://localhost:3000/auth/github/callback"),
-		spotify.New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "http://localhost:3000/auth/spotify/callback"),
-		linkedin.New(os.Getenv("LINKEDIN_KEY"), os.Getenv("LINKEDIN_SECRET"), "http://localhost:3000/auth/linkedin/callback"),
+		gplus.New(os.Getenv("GPLUS_KEY"), os.Getenv("GPLUS_SECRET"), "http://localhost:3000/auth/gplus/callback"),
 		lastfm.New(os.Getenv("LASTFM_KEY"), os.Getenv("LASTFM_SECRET"), "http://localhost:3000/auth/lastfm/callback"),
+		linkedin.New(os.Getenv("LINKEDIN_KEY"), os.Getenv("LINKEDIN_SECRET"), "http://localhost:3000/auth/linkedin/callback"),
+		spotify.New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "http://localhost:3000/auth/spotify/callback"),
 		twitch.New(os.Getenv("TWITCH_KEY"), os.Getenv("TWITCH_SECRET"), "http://localhost:3000/auth/twitch/callback"),
 		dropbox.New(os.Getenv("DROPBOX_KEY"), os.Getenv("DROPBOX_SECRET"), "http://localhost:3000/auth/dropbox/callback"),
 		digitalocean.New(os.Getenv("DIGITALOCEAN_KEY"), os.Getenv("DIGITALOCEAN_SECRET"), "http://localhost:3000/auth/digitalocean/callback", "read"),
+		twitter.New(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
 	)
 
 	// Assign the GetState function variable so we can return the
@@ -70,12 +70,13 @@ func main() {
 }
 
 var indexTemplate = `
-<p><a href="/auth/twitter">Log in with Twitter</a></p>
 <p><a href="/auth/facebook">Log in with Facebook</a></p>
-<p><a href="/auth/gplus">Log in with GPlus</a></p>
 <p><a href="/auth/github">Log in with Github</a></p>
-<p><a href="/auth/spotify">Log in with Spotify</a></p>
+<p><a href="/auth/gplus">Log in with GPlus</a></p>
 <p><a href="/auth/lastfm">Log in with LastFM</a></p>
+<p><a href="/auth/linkedin">Log in with LinkedIn</a></p>
+<p><a href="/auth/spotify">Log in with Spotify</a></p>
+<p><a href="/auth/twitter">Log in with Twitter</a></p>
 <p><a href="/auth/twitch">Log in with Twitch</a></p>
 <p><a href="/auth/dropbox">Log in with Dropbox</a></p>
 <p><a href="/auth/digitalocean">Log in with DigitalOcean</a></p>

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -54,11 +54,18 @@ func BeginAuthHandler(res http.ResponseWriter, req *http.Request) {
 	http.Redirect(res, req, url, http.StatusTemporaryRedirect)
 }
 
-// GetState gets the state string associated with the given request
+// SetState sets the state string associated with the given request.
 // This state is sent to the provider and can be retrieved during the
 // callback.
-var GetState = func(req *http.Request) string {
+var SetState = func() string {
 	return "state"
+}
+
+// GetState gets the state returned by the provider during the callback.
+// This is used to prevent CSRF attacks, see
+// http://tools.ietf.org/html/rfc6749#section-10.12
+var GetState = func(req *http.Request) string {
+	return req.URL.Query().Get("state")
 }
 
 /*
@@ -86,7 +93,7 @@ func GetAuthURL(res http.ResponseWriter, req *http.Request) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sess, err := provider.BeginAuth(GetState(req))
+	sess, err := provider.BeginAuth(SetState())
 	if err != nil {
 		return "", err
 	}

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -98,3 +98,20 @@ func Test_CompleteUserAuth(t *testing.T) {
 	a.Equal(user.Name, "Homer Simpson")
 	a.Equal(user.Email, "homer@example.com")
 }
+
+func Test_SetState(t *testing.T) {
+	t.Parallel()
+
+	a := assert.New(t)
+
+	a.Equal(SetState(), "state")
+}
+
+func Test_GetState(t *testing.T) {
+	t.Parallel()
+
+	a := assert.New(t)
+
+	req, _ := http.NewRequest("GET", "/auth?state=state", nil)
+	a.Equal(GetState(req), "state")
+}

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -3,7 +3,6 @@ package linkedin
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -58,7 +57,6 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	s := &Session{
 		AuthURL: url,
 	}
-	fmt.Println("The URL: ", url)
 	return s, nil
 }
 


### PR DESCRIPTION
This changes the way that the state parameter is dealt with. Previously, `GetState` was defined twice: once in `gothic.go`, and again in the example (`examples/main.go`). This redefinition changed the behaviour of `GetState` from returning a string to returning the value of the state parameter from the URL query string. That means that the state parameter wasn't being set by the client during the auth flow. That's okay for most providers, since sending a state parameter is optional... Except for with LinkedIn.

Now, there is a `SetState` and `GetState` function. `SetState` returns a string to be used when setting the `state` parameter as a client during the auth flow, and `GetState` returns the value of the `state` parameter in the query string returned by the provider.

If merged, this will close issue #33. 

I think this PR could use a review from @tylerb, since it looks like he first implemented the `GetState` function and likely knows more about what it's doing/should be doing than I do.

Also, I know that this current behaviour could use a bit more work, since we don't bother to check whether or not the `state` string returned by the provider is the same as the one set by the client, but I figured I should make this PR to fix the LinkedIn flow before working on that. :relaxed: