### PR TITLE
Fix LinkedIn auth flow, close #33

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -40,19 +40,12 @@ func main() {
 		bitbucket.New(os.Getenv("BITBUCKET_KEY"), os.Getenv("BITBUCKET_SECRET"), "http://localhost:3000/auth/bitbucket/callback"),
 	)
 
-	// Assign the GetState function variable so we can return the
-	// state string we want to get back at the end of the oauth process.
-	// Only works with facebook and gplus providers.
-	gothic.GetState = func(req *http.Request) string {
-		// Get the state string from the query parameters.
-		return req.URL.Query().Get("state")
-	}
-
 	p := pat.New()
 	p.Get("/auth/{provider}/callback", func(res http.ResponseWriter, req *http.Request) {
 
-		// print our state string to the console
-		fmt.Println(gothic.GetState(req))
+		// print our state string to the console. Ideally, you should verify
+		// that it's the same string as the one you set in `setState`
+		fmt.Println("State: ", gothic.GetState(req))
 
 		user, err := gothic.CompleteUserAuth(res, req)
 		if err != nil {

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -54,11 +54,18 @@ func BeginAuthHandler(res http.ResponseWriter, req *http.Request) {
 	http.Redirect(res, req, url, http.StatusTemporaryRedirect)
 }
 
-// GetState gets the state string associated with the given request
+// SetState sets the state string associated with the given request.
 // This state is sent to the provider and can be retrieved during the
 // callback.
-var GetState = func(req *http.Request) string {
+var SetState = func() string {
 	return "state"
+}
+
+// GetState gets the state returned by the provider during the callback.
+// This is used to prevent CSRF attacks, see
+// http://tools.ietf.org/html/rfc6749#section-10.12
+var GetState = func(req *http.Request) string {
+	return req.URL.Query().Get("state")
 }
 
 /*
@@ -86,7 +93,7 @@ func GetAuthURL(res http.ResponseWriter, req *http.Request) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sess, err := provider.BeginAuth(GetState(req))
+	sess, err := provider.BeginAuth(SetState())
 	if err != nil {
 		return "", err
 	}

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -98,3 +98,20 @@ func Test_CompleteUserAuth(t *testing.T) {
 	a.Equal(user.Name, "Homer Simpson")
 	a.Equal(user.Email, "homer@example.com")
 }
+
+func Test_SetState(t *testing.T) {
+	t.Parallel()
+
+	a := assert.New(t)
+
+	a.Equal(SetState(), "state")
+}
+
+func Test_GetState(t *testing.T) {
+	t.Parallel()
+
+	a := assert.New(t)
+
+	req, _ := http.NewRequest("GET", "/auth?state=state", nil)
+	a.Equal(GetState(req), "state")
+}


### PR DESCRIPTION
This changes the way that the state parameter is dealt with. Previously, `GetState` was defined twice: once in `gothic.go`, and again in the example (`examples/main.go`). This redefinition changed the behaviour of `GetState` from returning a string to returning the value of the state parameter from the URL query string. That means that the state parameter wasn't being set by the client during the auth flow.
That's okay for most providers, since sending a state parameter is optional... Except for with LinkedIn.

Now, there is a `SetState` and `GetState` function. `SetState` returns a string to be used when setting the `state` parameter as a client during the auth flow, and `GetState` returns the value of the `state` parameter in the query string returned by the provider.

(Just a rebase of #45, I didn't realize how badly I botched the rebase on that one).