### PR TITLE
Fix LinkedIn state passing

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -57,7 +57,11 @@ func BeginAuthHandler(res http.ResponseWriter, req *http.Request) {
 // SetState sets the state string associated with the given request.
 // This state is sent to the provider and can be retrieved during the
 // callback.
-var SetState = func() string {
+var SetState = func(req *http.Request) string {
+	state := req.URL.Query().Get("state")
+	if len(state) > 0 {
+		return state
+	}
 	return "state"
 }
 
@@ -93,7 +97,7 @@ func GetAuthURL(res http.ResponseWriter, req *http.Request) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sess, err := provider.BeginAuth(SetState())
+	sess, err := provider.BeginAuth(SetState(req))
 	if err != nil {
 		return "", err
 	}

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -104,7 +104,8 @@ func Test_SetState(t *testing.T) {
 
 	a := assert.New(t)
 
-	a.Equal(SetState(), "state")
+	req, _ := http.NewRequest("GET", "/auth?state=state", nil)
+	a.Equal(SetState(req), "state")
 }
 
 func Test_GetState(t *testing.T) {


### PR DESCRIPTION
This restores the ability to pass a state parameter to the LinkedIn
provider by sending the state value on the query string. However, if no
state is passed, as LinkedIn required the parameter, a string will be
returned in its place.