### PR TITLE
added the gorilla mux way of reading  out url parameters

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/gorilla/sessions"
+	"github.com/gorilla/mux"
 	"github.com/markbates/goth"
 )
 
@@ -173,6 +174,10 @@ func getProviderName(req *http.Request) (string, error) {
 	provider := req.URL.Query().Get("provider")
 	if provider == "" {
 		provider = req.URL.Query().Get(":provider")
+	}
+	if provider == "" {
+		params := mux.Vars(req)
+		provider = params["provider"]
 	}
 	if provider == "" {
 		return provider, errors.New("you must select a provider")


### PR DESCRIPTION
When using a gorilla mux router, this library was not supported in this verison of goth. I added this possibility.