### PR TITLE
Changed "let's" to "lets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Package goth provides a simple, clean, and idiomatic way to write authentication
 packages for Go web applications.
 
-Unlike other similar packages, Goth, let's you write OAuth, OAuth2, or any other
+Unlike other similar packages, Goth, lets you write OAuth, OAuth2, or any other
 protocol providers, as long as they implement the `Provider` and `Session` interfaces.
 
 This package was inspired by [https://github.com/intridea/omniauth](https://github.com/intridea/omniauth).


### PR DESCRIPTION
"let's" is a contraction for "let us", where lets means to allow.