### PR TITLE
Fixed http exotic connection leak

### DIFF
--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -66,8 +66,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
-
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -69,6 +69,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()
@@ -87,6 +90,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err = http.Get(endpointEmail + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -69,6 +69,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "&access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -70,6 +70,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -69,6 +69,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -17,7 +17,7 @@ import (
 var (
 	authURL         = "https://api.instagram.com/oauth/authorize/"
 	tokenURL        = "https://api.instagram.com/oauth/access_token"
-	endPointProfile = "https://api.instagram.com/v1/users/self/"
+	endpointProfile = "https://api.instagram.com/v1/users/self/"
 )
 
 // New creates a new Instagram provider, and sets up important connection details.
@@ -65,8 +65,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(endPointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -67,6 +67,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
 		return user, err
 	}
 	defer response.Body.Close()


### PR DESCRIPTION
Fixes issues #65

Although the changes seem simple, I currently don't have the time to configure my environment to test the APIs on the various providers. I will be able to test some of them when my next project starts in 3-4 weeks. Before then you need a test environment to validate the PR.

PS : some linters (errcheck) encourage being explicit with the use or non-use (ignore underscore _) of function return values. E.g., they would force the patch to use this style in the error escape paths :
_ = response.Body.Close()
instead of
response.Body.Close()
I noticed you dont follow the second alternative, so I aligned the patch coding style on yours.