### PR TITLE
Added Refresh Token/Expiry Date of Access Token for applicable providers

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -112,4 +112,6 @@ var userTemplate = `
 <p>Description: {{.Description}}</p>
 <p>UserID: {{.UserID}}</p>
 <p>AccessToken: {{.AccessToken}}</p>
+<p>ExpiresIn: {{.ExpiresIn}}</p>
+<p>RefreshToken: {{.RefreshToken}}</p>
 `

--- a/examples/main.go
+++ b/examples/main.go
@@ -10,7 +10,9 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
+	"github.com/markbates/goth/providers/amazon"
 	"github.com/markbates/goth/providers/bitbucket"
+	"github.com/markbates/goth/providers/box"
 	"github.com/markbates/goth/providers/digitalocean"
 	"github.com/markbates/goth/providers/dropbox"
 	"github.com/markbates/goth/providers/facebook"
@@ -19,14 +21,12 @@ import (
 	"github.com/markbates/goth/providers/instagram"
 	"github.com/markbates/goth/providers/lastfm"
 	"github.com/markbates/goth/providers/linkedin"
+	"github.com/markbates/goth/providers/onedrive"
+	"github.com/markbates/goth/providers/salesforce"
 	"github.com/markbates/goth/providers/spotify"
 	"github.com/markbates/goth/providers/twitch"
 	"github.com/markbates/goth/providers/twitter"
-	"github.com/markbates/goth/providers/box"
-	"github.com/markbates/goth/providers/salesforce"
-	"github.com/markbates/goth/providers/amazon"
 	"github.com/markbates/goth/providers/yammer"
-	"github.com/markbates/goth/providers/onedrive"
 )
 
 func init() {
@@ -55,8 +55,6 @@ func main() {
 		amazon.New(os.Getenv("AMAZON_KEY"), os.Getenv("AMAZON_SECRET"), "http://localhost:3000/auth/amazon/callback"),
 		yammer.New(os.Getenv("YAMMER_KEY"), os.Getenv("YAMMER_SECRET"), "http://localhost:3000/auth/yammer/callback"),
 		onedrive.New(os.Getenv("ONEDRIVE_KEY"), os.Getenv("ONEDRIVE_SECRET"), "http://localhost:3000/auth/onedrive/callback"),
-
-
 	)
 
 	p := pat.New()
@@ -112,6 +110,6 @@ var userTemplate = `
 <p>Description: {{.Description}}</p>
 <p>UserID: {{.UserID}}</p>
 <p>AccessToken: {{.AccessToken}}</p>
-<p>ExpiresIn: {{.ExpiresIn}}</p>
+<p>ExpiresAt: {{.ExpiresAt}}</p>
 <p>RefreshToken: {{.RefreshToken}}</p>
 `

--- a/provider.go
+++ b/provider.go
@@ -12,7 +12,7 @@ type Provider interface {
 	FetchUser(Session) (User, error)
 	Debug(bool)
 	RefreshToken(refreshToken string) (*oauth2.Token, error) //Get new access token based on the refresh token
-	RefreshTokenAvailable()(bool) //Refresh token is provided by auth provider or not
+	RefreshTokenAvailable() bool                             //Refresh token is provided by auth provider or not
 }
 
 // Providers is list of known/available providers.

--- a/provider.go
+++ b/provider.go
@@ -1,6 +1,7 @@
 package goth
 
 import "fmt"
+import "golang.org/x/oauth2"
 
 // Provider needs to be implemented for each 3rd party authentication provider
 // e.g. Facebook, Twitter, etc...
@@ -10,6 +11,8 @@ type Provider interface {
 	UnmarshalSession(string) (Session, error)
 	FetchUser(Session) (User, error)
 	Debug(bool)
+	RefreshToken(refreshToken string) (*oauth2.Token, error) //Get new access token based on the refresh token
+	RefreshTokenAvailable()(bool) //Refresh token is provided by auth provider or not
 }
 
 // Providers is list of known/available providers.

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -63,6 +63,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:sess.RefreshToken,
+		ExpiresIn:sess.ExpiresIn,
 	}
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
@@ -134,4 +136,20 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.UserID = u.Id
 	user.Location=u.Location
 	return nil
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/amazon/amazon_test.go
+++ b/providers/amazon/amazon_test.go
@@ -1,11 +1,11 @@
 package amazon_test
 
 import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/amazon"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"github.com/markbates/goth"
-	"github.com/stretchr/testify/assert"
-	"github.com/markbates/goth/providers/amazon"
 )
 
 func Test_New(t *testing.T) {
@@ -23,7 +23,6 @@ func Test_Implements_Provider(t *testing.T) {
 	a := assert.New(t)
 	a.Implements((*goth.Provider)(nil), provider())
 }
-
 
 func Test_BeginAuth(t *testing.T) {
 	t.Parallel()

--- a/providers/amazon/session.go
+++ b/providers/amazon/session.go
@@ -3,16 +3,17 @@ package amazon
 import (
 	"encoding/json"
 	"errors"
-
 	"golang.org/x/oauth2"
-
+	"time"
 	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -25,15 +26,16 @@ func (s Session) GetAuthURL() (string, error) {
 	return s.AuthURL, nil
 }
 
-// Authorize the session with Box and return the access token to be stored for future use.
+// Authorize the session with Amazon and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
 	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
 	if err != nil {
 		return "", err
 	}
-
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/amazon/session.go
+++ b/providers/amazon/session.go
@@ -3,9 +3,9 @@ package amazon
 import (
 	"encoding/json"
 	"errors"
+	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 	"time"
-	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -35,7 +35,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/amazon/session_test.go
+++ b/providers/amazon/session_test.go
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &amazon.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/amazon/session_test.go
+++ b/providers/amazon/session_test.go
@@ -1,10 +1,10 @@
 package amazon_test
 
 import (
-	"testing"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/amazon"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_Implements_Session(t *testing.T) {
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &amazon.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -63,10 +63,10 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
-		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
-		RefreshToken:sess.RefreshToken,
-		ExpiresIn:sess.ExpiresIn,
+		AccessToken:  sess.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: sess.RefreshToken,
+		ExpiresAt:    sess.ExpiresAt,
 	}
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
@@ -117,12 +117,12 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID       string `json:"uuid"`
-		Links    struct {
-					 Avatar struct {
-								URL string `json:"href"`
-							} `json:"avatar"`
-				 } `json:"links"`
+		ID    string `json:"uuid"`
+		Links struct {
+			Avatar struct {
+				URL string `json:"href"`
+			} `json:"avatar"`
+		} `json:"links"`
 		Email    string `json:"email"`
 		Username string `json:"username"`
 		Name     string `json:"display_name"`
@@ -181,14 +181,14 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -65,6 +65,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:sess.RefreshToken,
+		ExpiresIn:sess.ExpiresIn,
 	}
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
@@ -115,12 +117,12 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID    string `json:"uuid"`
-		Links struct {
-			Avatar struct {
-				URL string `json:"href"`
-			} `json:"avatar"`
-		} `json:"links"`
+		ID       string `json:"uuid"`
+		Links    struct {
+					 Avatar struct {
+								URL string `json:"href"`
+							} `json:"avatar"`
+				 } `json:"links"`
 		Email    string `json:"email"`
 		Username string `json:"username"`
 		Name     string `json:"display_name"`
@@ -177,4 +179,20 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	}
 
 	return c
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/bitbucket/bitbucket_test.go
+++ b/providers/bitbucket/bitbucket_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/markbates/goth/providers/bitbucket"
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/bitbucket"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/bitbucket/session.go
+++ b/providers/bitbucket/session.go
@@ -3,16 +3,17 @@ package bitbucket
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"golang.org/x/oauth2"
-
 	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Bitbucket.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Bitbucket provider.
@@ -30,8 +31,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
-
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/bitbucket/session.go
+++ b/providers/bitbucket/session.go
@@ -3,9 +3,9 @@ package bitbucket
 import (
 	"encoding/json"
 	"errors"
-	"time"
-	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Bitbucket.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Bitbucket provider.
@@ -33,7 +33,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/bitbucket/session_test.go
+++ b/providers/bitbucket/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &bitbucket.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/bitbucket/session_test.go
+++ b/providers/bitbucket/session_test.go
@@ -3,8 +3,8 @@ package bitbucket_test
 import (
 	"testing"
 
-	"github.com/markbates/goth/providers/bitbucket"
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/bitbucket"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &bitbucket.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -59,6 +59,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:s.RefreshToken,
+		ExpiresIn:s.ExpiresIn,
 	}
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
@@ -124,4 +126,20 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.UserID = u.Id
 	user.Location = u.Location
 	return nil
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -4,17 +4,17 @@ package box
 
 import (
 	"encoding/json"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"strings"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 const (
-	authURL            string = "https://app.box.com/api/oauth2/authorize"
-	tokenURL           string = "https://app.box.com/api/oauth2/token"
-	endpointProfile    string = "https://api.box.com/2.0/users/me"
+	authURL         string = "https://app.box.com/api/oauth2/authorize"
+	tokenURL        string = "https://app.box.com/api/oauth2/token"
+	endpointProfile string = "https://api.box.com/2.0/users/me"
 )
 
 // Provider is the implementation of `goth.Provider` for accessing Box.
@@ -57,10 +57,10 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
-		AccessToken: s.AccessToken,
-		Provider:    p.Name(),
-		RefreshToken:s.RefreshToken,
-		ExpiresIn:s.ExpiresIn,
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+		ExpiresAt:    s.ExpiresAt,
 	}
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
@@ -110,11 +110,11 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 
 func userFromReader(r io.Reader, user *goth.User) error {
 	u := struct {
-		Name        string `json:"name"`
-		Location    string `json:"address"`
-		Email       string `json:"login"`
-		AvatarURL   string `json:"avatar_url"`
-		Id          string `json:"id"`
+		Name      string `json:"name"`
+		Location  string `json:"address"`
+		Email     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+		ID        string `json:"id"`
 	}{}
 	err := json.NewDecoder(r).Decode(&u)
 	if err != nil {
@@ -123,19 +123,19 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.Email = u.Email
 	user.Name = u.Name
 	user.NickName = u.Name
-	user.UserID = u.Id
+	user.UserID = u.ID
 	user.Location = u.Location
 	return nil
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/box/box_test.go
+++ b/providers/box/box_test.go
@@ -1,11 +1,11 @@
 package box_test
 
 import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/box"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"github.com/markbates/goth"
-	"github.com/stretchr/testify/assert"
-	"github.com/markbates/goth/providers/box"
 )
 
 func Test_New(t *testing.T) {
@@ -23,7 +23,6 @@ func Test_Implements_Provider(t *testing.T) {
 	a := assert.New(t)
 	a.Implements((*goth.Provider)(nil), provider())
 }
-
 
 func Test_BeginAuth(t *testing.T) {
 	t.Parallel()

--- a/providers/box/session.go
+++ b/providers/box/session.go
@@ -3,9 +3,9 @@ package box
 import (
 	"encoding/json"
 	"errors"
-	"time"
-	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Box.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -35,7 +35,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/box/session.go
+++ b/providers/box/session.go
@@ -3,16 +3,17 @@ package box
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"golang.org/x/oauth2"
-
 	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -32,8 +33,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
-
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/box/session_test.go
+++ b/providers/box/session_test.go
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &box.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/box/session_test.go
+++ b/providers/box/session_test.go
@@ -1,10 +1,10 @@
 package box_test
 
 import (
-	"testing"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/box"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_Implements_Session(t *testing.T) {
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &box.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -3,12 +3,12 @@ package digitalocean
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -62,10 +62,10 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
-		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
-		RefreshToken:sess.RefreshToken,
-		ExpiresIn:sess.ExpiresIn,
+		AccessToken:  sess.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: sess.RefreshToken,
+		ExpiresAt:    sess.ExpiresAt,
 	}
 
 	client := &http.Client{}
@@ -109,13 +109,13 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
 		Account struct {
-					DropletLimit  int    `json:"droplet_limit"`
-					Email         string `json:"email"`
-					UUID          string `json:"uuid"`
-					EmailVerified bool   `json:"email_verified"`
-					Status        string `json:"status"`
-					StatusMessage string `json:"status_message"`
-				} `json:"account"`
+			DropletLimit  int    `json:"droplet_limit"`
+			Email         string `json:"email"`
+			UUID          string `json:"uuid"`
+			EmailVerified bool   `json:"email_verified"`
+			Status        string `json:"status"`
+			StatusMessage string `json:"status_message"`
+		} `json:"account"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -148,14 +148,14 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -65,6 +64,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:sess.RefreshToken,
+		ExpiresIn:sess.ExpiresIn,
 	}
 
 	client := &http.Client{}
@@ -108,13 +109,13 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
 		Account struct {
-			DropletLimit  int    `json:"droplet_limit"`
-			Email         string `json:"email"`
-			UUID          string `json:"uuid"`
-			EmailVerified bool   `json:"email_verified"`
-			Status        string `json:"status"`
-			StatusMessage string `json:"status_message"`
-		} `json:"account"`
+					DropletLimit  int    `json:"droplet_limit"`
+					Email         string `json:"email"`
+					UUID          string `json:"uuid"`
+					EmailVerified bool   `json:"email_verified"`
+					Status        string `json:"status"`
+					StatusMessage string `json:"status_message"`
+				} `json:"account"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -145,4 +146,20 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	}
 
 	return c
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/digitalocean/session.go
+++ b/providers/digitalocean/session.go
@@ -3,16 +3,17 @@ package digitalocean
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"golang.org/x/oauth2"
-
 	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with DigitalOcean.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -32,8 +33,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
-
 	s.AccessToken = token.AccessToken
+	s.RefreshToken=token.RefreshToken
+	s.ExpiresIn=token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/digitalocean/session.go
+++ b/providers/digitalocean/session.go
@@ -3,9 +3,9 @@ package digitalocean
 import (
 	"encoding/json"
 	"errors"
-	"time"
-	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with DigitalOcean.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -34,8 +34,8 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
-	s.RefreshToken=token.RefreshToken
-	s.ExpiresIn=token.Expiry
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/digitalocean/session_test.go
+++ b/providers/digitalocean/session_test.go
@@ -27,7 +27,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &digitalocean.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/digitalocean/session_test.go
+++ b/providers/digitalocean/session_test.go
@@ -27,7 +27,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &digitalocean.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -4,16 +4,16 @@ package dropbox
 import (
 	"encoding/json"
 	"errors"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"strings"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 const (
-	authURL = "https://www.dropbox.com/1/oauth2/authorize"
-	tokenURL = "https://api.dropbox.com/1/oauth2/token"
+	authURL    = "https://www.dropbox.com/1/oauth2/authorize"
+	tokenURL   = "https://api.dropbox.com/1/oauth2/token"
 	accountURL = "https://api.dropbox.com/1/account/info"
 )
 
@@ -137,10 +137,10 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	u := struct {
 		Name        string `json:"display_name"`
 		NameDetails struct {
-						NickName string `json:"familiar_name"`
-					} `json:"name_details"`
-		Location    string `json:"country"`
-		Email       string `json:"email"`
+			NickName string `json:"familiar_name"`
+		} `json:"name_details"`
+		Location string `json:"country"`
+		Email    string `json:"email"`
 	}{}
 	err := json.NewDecoder(r).Decode(&u)
 	if err != nil {
@@ -154,12 +154,12 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	return nil
 }
 
-//refresh token is not provided by dropbox
+//RefreshToken refresh token is not provided by dropbox
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by dropbox")
 }
 
-//refresh token is not provided by dropbox
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by dropbox
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -7,14 +7,13 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
 
 const (
-	authURL    = "https://www.dropbox.com/1/oauth2/authorize"
-	tokenURL   = "https://api.dropbox.com/1/oauth2/token"
+	authURL = "https://www.dropbox.com/1/oauth2/authorize"
+	tokenURL = "https://api.dropbox.com/1/oauth2/token"
 	accountURL = "https://api.dropbox.com/1/account/info"
 )
 
@@ -138,10 +137,10 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	u := struct {
 		Name        string `json:"display_name"`
 		NameDetails struct {
-			NickName string `json:"familiar_name"`
-		} `json:"name_details"`
-		Location string `json:"country"`
-		Email    string `json:"email"`
+						NickName string `json:"familiar_name"`
+					} `json:"name_details"`
+		Location    string `json:"country"`
+		Email       string `json:"email"`
 	}{}
 	err := json.NewDecoder(r).Decode(&u)
 	if err != nil {
@@ -153,4 +152,14 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.UserID = u.Email // Dropbox doesn't provide a separate user ID
 	user.Location = u.Location
 	return nil
+}
+
+//refresh token is not provided by dropbox
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by dropbox")
+}
+
+//refresh token is not provided by dropbox
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
 }

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -5,14 +5,14 @@ package facebook
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
-	"errors"
 )
 
 const (
@@ -63,9 +63,9 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
-		AccessToken:   sess.AccessToken,
-		Provider:      p.Name(),
-		ExpiresIn:     sess.ExpiresIn,
+		AccessToken: sess.AccessToken,
+		Provider:    p.Name(),
+		ExpiresAt:   sess.ExpiresAt,
 	}
 
 	response, err := http.Get(endpointProfile + "&access_token=" + url.QueryEscape(sess.AccessToken))
@@ -100,19 +100,19 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID       string `json:"id"`
-		Email    string `json:"email"`
-		Bio      string `json:"bio"`
-		Name     string `json:"name"`
-		Link     string `json:"link"`
-		Picture  struct {
-					 Data struct {
-							  URL string `json:"url"`
-						  } `json:"data"`
-				 } `json:"picture"`
+		ID      string `json:"id"`
+		Email   string `json:"email"`
+		Bio     string `json:"bio"`
+		Name    string `json:"name"`
+		Link    string `json:"link"`
+		Picture struct {
+			Data struct {
+				URL string `json:"url"`
+			} `json:"data"`
+		} `json:"picture"`
 		Location struct {
-					 Name string `json:"name"`
-				 } `json:"location"`
+			Name string `json:"name"`
+		} `json:"location"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -145,7 +145,7 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 		},
 	}
 
-	defaultScopes := map[string]struct {}{
+	defaultScopes := map[string]struct{}{
 		"email": {},
 	}
 
@@ -158,12 +158,12 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//refresh token is not provided by facebook
+//RefreshToken refresh token is not provided by facebook
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by facebook")
 }
 
-//refresh token is not provided by facebook
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by facebook
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -3,7 +3,7 @@ package facebook
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -12,6 +12,7 @@ import (
 type Session struct {
 	AuthURL     string
 	AccessToken string
+	ExpiresIn   time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Facebook provider.
@@ -30,6 +31,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -3,16 +3,16 @@ package facebook
 import (
 	"encoding/json"
 	"errors"
-	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Facebook.
 type Session struct {
 	AuthURL     string
 	AccessToken string
-	ExpiresIn   time.Time
+	ExpiresAt   time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Facebook provider.
@@ -31,7 +31,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/facebook/session_test.go
+++ b/providers/facebook/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &facebook.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/facebook/session_test.go
+++ b/providers/facebook/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &facebook.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -4,9 +4,9 @@ package faux
 
 import (
 	"encoding/json"
-	"strings"
-	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"strings"
 )
 
 // Provider is used only for testing.
@@ -54,7 +54,7 @@ func (p *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 }
 
 //RefreshTokenAvailable is used only for testing
-func (p *Provider) RefreshTokenAvailable() (bool) {
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -5,7 +5,7 @@ package faux
 import (
 	"encoding/json"
 	"strings"
-
+	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
 )
 
@@ -51,6 +51,16 @@ func (p *Provider) Debug(debug bool) {}
 // Authorize is used only for testing.
 func (p *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	return "", nil
+}
+
+//RefreshTokenAvailable is used only for testing
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//RefreshToken is used only for testing
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, nil
 }
 
 // Marshal is used only for testing.

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -5,15 +5,15 @@ package github
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -143,12 +143,12 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//refresh token is not provided by github
+//RefreshToken refresh token is not provided by github
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by github")
 }
 
-//refresh token is not provided by github
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by github
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
+	"errors"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -141,4 +141,14 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	}
 
 	return c
+}
+
+//refresh token is not provided by github
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by github")
+}
+
+//refresh token is not provided by github
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
 }

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -63,10 +63,10 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
-		AccessToken:     sess.AccessToken,
-		Provider:        p.Name(),
-		RefreshToken:    sess.RefreshToken,
-		ExpiresIn:       sess.ExpiresIn,
+		AccessToken:  sess.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: sess.RefreshToken,
+		ExpiresAt:    sess.ExpiresAt,
 	}
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
@@ -146,14 +146,14 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {
@@ -161,5 +161,3 @@ func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	}
 	return newToken, err
 }
-
-

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -3,15 +3,17 @@ package gplus
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
 
 // Session stores data during the auth process with Facebook.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Google+ provider.
@@ -30,6 +32,8 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -3,9 +3,9 @@ package gplus
 import (
 	"encoding/json"
 	"errors"
-	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Facebook.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Google+ provider.
@@ -33,7 +33,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/gplus/session_test.go
+++ b/providers/gplus/session_test.go
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/gplus/session_test.go
+++ b/providers/gplus/session_test.go
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -3,14 +3,14 @@ package instagram
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"errors"
-	"golang.org/x/oauth2"
-	"github.com/markbates/goth"
 )
 
 var (
@@ -49,6 +49,7 @@ func (p *Provider) Name() string {
 //Debug TODO
 func (p *Provider) Debug(debug bool) {}
 
+// BeginAuth asks Instagram for an authentication end-point.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	url := p.config.AuthCodeURL(state)
 	session := &Session{
@@ -57,6 +58,7 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	return session, nil
 }
 
+// FetchUser will go to Instagram and access basic information about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
@@ -145,12 +147,12 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//refresh token is not provided by instagram
+//RefreshToken refresh token is not provided by instagram
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by instagram")
 }
 
-//refresh token is not provided by instagram
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by instagram
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -8,9 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-
+	"errors"
 	"golang.org/x/oauth2"
-
 	"github.com/markbates/goth"
 )
 
@@ -144,4 +143,14 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	}
 
 	return c
+}
+
+//refresh token is not provided by instagram
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by instagram")
+}
+
+//refresh token is not provided by instagram
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
 }

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -14,7 +14,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-
+	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
 )
 
@@ -211,4 +211,14 @@ func signRequest(secret string, params map[string]string) string {
 	hasher := md5.New()
 	hasher.Write([]byte(sigPlain))
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+//refresh token is not provided by lastfm
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by lastfm")
+}
+
+//refresh token is not provided by lastfm
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
 }

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -3,12 +3,12 @@ package linkedin
 
 import (
 	"encoding/json"
+	"errors"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
-	"errors"
 )
 
 //more details about linkedin fields: https://developer.linkedin.com/documents/profile-fields
@@ -17,7 +17,7 @@ const (
 	authURL  string = "https://www.linkedin.com/uas/oauth2/authorization"
 	tokenURL string = "https://www.linkedin.com/uas/oauth2/accessToken"
 
-//userEndpoint requires scopes "r_basicprofile", "r_emailaddress"
+	//userEndpoint requires scopes "r_basicprofile", "r_emailaddress"
 	userEndpoint string = "//api.linkedin.com/v1/people/~:(id,first-name,last-name,headline,location:(name),picture-url,email-address)"
 )
 
@@ -65,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
-		ExpiresIn:   s.ExpiresIn,
+		ExpiresAt:   s.ExpiresAt,
 	}
 
 	req, err := http.NewRequest("GET", "", nil)
@@ -112,8 +112,8 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		Headline   string `json:"headline"`
 		PictureURL string `json:"pictureUrl"`
 		Location   struct {
-					   Name string `json:"name"`
-				   } `json:"location"`
+			Name string `json:"name"`
+		} `json:"location"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -151,12 +151,12 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//refresh token is not provided by linkedin
+//RefreshToken refresh token is not provided by linkedin
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by linkedin")
 }
 
-//refresh token is not provided by linkedin
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by linkedin
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -5,11 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-
 	"net/url"
-
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"errors"
 )
 
 //more details about linkedin fields: https://developer.linkedin.com/documents/profile-fields
@@ -18,7 +17,7 @@ const (
 	authURL  string = "https://www.linkedin.com/uas/oauth2/authorization"
 	tokenURL string = "https://www.linkedin.com/uas/oauth2/accessToken"
 
-	//userEndpoint requires scopes "r_basicprofile", "r_emailaddress"
+//userEndpoint requires scopes "r_basicprofile", "r_emailaddress"
 	userEndpoint string = "//api.linkedin.com/v1/people/~:(id,first-name,last-name,headline,location:(name),picture-url,email-address)"
 )
 
@@ -66,6 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
+		ExpiresIn:   s.ExpiresIn,
 	}
 
 	req, err := http.NewRequest("GET", "", nil)
@@ -112,8 +112,8 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		Headline   string `json:"headline"`
 		PictureURL string `json:"pictureUrl"`
 		Location   struct {
-			Name string `json:"name"`
-		} `json:"location"`
+					   Name string `json:"name"`
+				   } `json:"location"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -149,4 +149,14 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 	}
 
 	return c
+}
+
+//refresh token is not provided by linkedin
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by linkedin")
+}
+
+//refresh token is not provided by linkedin
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
 }

--- a/providers/linkedin/session.go
+++ b/providers/linkedin/session.go
@@ -3,16 +3,16 @@ package linkedin
 import (
 	"encoding/json"
 	"errors"
-	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Linkedin.
 type Session struct {
 	AuthURL     string
 	AccessToken string
-	ExpiresIn   time.Time
+	ExpiresAt   time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Linkedin provider.
@@ -31,7 +31,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/linkedin/session.go
+++ b/providers/linkedin/session.go
@@ -3,7 +3,7 @@ package linkedin
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -12,6 +12,7 @@ import (
 type Session struct {
 	AuthURL     string
 	AccessToken string
+	ExpiresIn   time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Linkedin provider.
@@ -30,6 +31,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/linkedin/session_test.go
+++ b/providers/linkedin/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &linkedin.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/linkedin/session_test.go
+++ b/providers/linkedin/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &linkedin.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/onedrive/onedrive_test.go
+++ b/providers/onedrive/onedrive_test.go
@@ -1,11 +1,11 @@
 package onedrive_test
 
 import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/onedrive"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"github.com/markbates/goth"
-	"github.com/stretchr/testify/assert"
-	"github.com/markbates/goth/providers/onedrive"
 )
 
 func Test_New(t *testing.T) {
@@ -23,7 +23,6 @@ func Test_Implements_Provider(t *testing.T) {
 	a := assert.New(t)
 	a.Implements((*goth.Provider)(nil), provider())
 }
-
 
 func Test_BeginAuth(t *testing.T) {
 	t.Parallel()

--- a/providers/onedrive/session.go
+++ b/providers/onedrive/session.go
@@ -3,9 +3,9 @@ package onedrive
 import (
 	"encoding/json"
 	"errors"
-	"time"
-	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Box.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -36,7 +36,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/onedrive/session.go
+++ b/providers/onedrive/session.go
@@ -3,16 +3,17 @@ package onedrive
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"golang.org/x/oauth2"
-
 	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 var _ goth.Session = &Session{}
@@ -34,6 +35,8 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/onedrive/session_test.go
+++ b/providers/onedrive/session_test.go
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &onedrive.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/onedrive/session_test.go
+++ b/providers/onedrive/session_test.go
@@ -1,10 +1,10 @@
 package onedrive_test
 
 import (
-	"testing"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/onedrive"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_Implements_Session(t *testing.T) {
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &onedrive.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -60,6 +60,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:s.RefreshToken,
 	}
 	url, err := url.Parse(s.Id)
 	//creating dynamic url to retrieve user information
@@ -129,4 +130,20 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.UserID = u.Id
 	user.Location = u.Location
 	return nil
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -4,17 +4,18 @@ package salesforce
 
 import (
 	"encoding/json"
-	"io"
-	"net/http"
-	"strings"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"io"
+	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
-	authURL            string = "https://login.salesforce.com/services/oauth2/authorize"
-	tokenURL           string = "https://login.salesforce.com/services/oauth2/token"
+	authURL  string = "https://login.salesforce.com/services/oauth2/authorize"
+	tokenURL string = "https://login.salesforce.com/services/oauth2/token"
+
 //endpointProfile    string = "https://api.salesforce.com/2.0/users/me"
 )
 
@@ -58,14 +59,14 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
-		AccessToken: s.AccessToken,
-		Provider:    p.Name(),
-		RefreshToken:s.RefreshToken,
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
 	}
-	url, err := url.Parse(s.Id)
+	url, err := url.Parse(s.ID)
 	//creating dynamic url to retrieve user information
-	userUrl := url.Scheme+"://"+url.Host+"/"+url.Path
-	req, err := http.NewRequest("GET", userUrl, nil)
+	userURL := url.Scheme + "://" + url.Host + "/" + url.Path
+	req, err := http.NewRequest("GET", userURL, nil)
 	if err != nil {
 		return user, err
 	}
@@ -118,7 +119,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		Location  string `json:"addr_country"`
 		Email     string `json:"email"`
 		AvatarURL string `json:"photos.picture"`
-		Id        string `json:"user_id"`
+		ID        string `json:"user_id"`
 	}{}
 	err := json.NewDecoder(r).Decode(&u)
 	if err != nil {
@@ -127,19 +128,19 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.Email = u.Email
 	user.Name = u.Name
 	user.NickName = u.Name
-	user.UserID = u.Id
+	user.UserID = u.ID
 	user.Location = u.Location
 	return nil
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/salesforce/salesforce_test.go
+++ b/providers/salesforce/salesforce_test.go
@@ -1,12 +1,11 @@
 package salesforce_test
 
-
 import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/salesforce"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"github.com/markbates/goth"
-	"github.com/stretchr/testify/assert"
-	"github.com/markbates/goth/providers/salesforce"
 )
 
 func Test_New(t *testing.T) {
@@ -24,7 +23,6 @@ func Test_Implements_Provider(t *testing.T) {
 	a := assert.New(t)
 	a.Implements((*goth.Provider)(nil), provider())
 }
-
 
 func Test_BeginAuth(t *testing.T) {
 	t.Parallel()

--- a/providers/salesforce/session.go
+++ b/providers/salesforce/session.go
@@ -3,8 +3,8 @@ package salesforce
 import (
 	"encoding/json"
 	"errors"
-	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 // Session stores data during the auth process with Salesforce.
@@ -21,7 +21,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	Id           string //Required to get the user info from sales force
+	ID           string //Required to get the user info from sales force
 }
 
 var _ goth.Session = &Session{}
@@ -39,13 +39,12 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	p := provider.(*Provider)
 	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
 
-
 	if err != nil {
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.Id=token.Extra("id").(string) //Required to get the user info from sales force
+	s.ID = token.Extra("id").(string) //Required to get the user info from sales force
 	return token.AccessToken, err
 }
 

--- a/providers/salesforce/session.go
+++ b/providers/salesforce/session.go
@@ -8,10 +8,20 @@ import (
 )
 
 // Session stores data during the auth process with Salesforce.
+// Expiry of access token is not provided by Salesforce, it is just controlled by timeout configured in auth2 settings
+// by individual users
+// Only way to check whether access token has expired or not is based on the response you receive if you try using
+// access token and get some error
+// Also, For salesforce refresh token to work follow these else remove scopes from here
+//On salesforce.com, navigate to where you app is configured. (Setup > Create > Apps)
+//Under Connected Apps, click on your application's name to view its settings, then click Edit.
+//Under Selected OAuth Scopes, ensure that "Perform requests on your behalf at any time" is selected. You must include this even if you already chose "Full access".
+//Save, then try your OAuth flow again. It make take a short while for the update to propagate.
 type Session struct {
-	AuthURL     string
-	AccessToken string
-	Id          string //Required to get the user info from sales force
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	Id           string //Required to get the user info from sales force
 }
 
 var _ goth.Session = &Session{}
@@ -34,6 +44,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
 	s.Id=token.Extra("id").(string) //Required to get the user info from sales force
 	return token.AccessToken, err
 }

--- a/providers/salesforce/session_test.go
+++ b/providers/salesforce/session_test.go
@@ -1,11 +1,10 @@
 package salesforce_test
 
-
 import (
-	"testing"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/salesforce"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_Implements_Session(t *testing.T) {
@@ -36,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &salesforce.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","Id":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ID":""}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/salesforce/session_test.go
+++ b/providers/salesforce/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &salesforce.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","Id":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","Id":""}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -3,9 +3,9 @@ package spotify
 import (
 	"encoding/json"
 	"errors"
-	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Spotify.
@@ -13,7 +13,7 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the
@@ -35,7 +35,7 @@ func (s Session) Authorize(provider goth.Provider, params goth.Params) (string, 
 	}
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -3,15 +3,17 @@ package spotify
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
 
 // Session stores data during the auth process with Spotify.
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the
@@ -32,6 +34,8 @@ func (s Session) Authorize(provider goth.Provider, params goth.Params) (string, 
 		return "", err
 	}
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/spotify/session_test.go
+++ b/providers/spotify/session_test.go
@@ -33,5 +33,5 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }

--- a/providers/spotify/session_test.go
+++ b/providers/spotify/session_test.go
@@ -33,5 +33,5 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -91,6 +90,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:s.RefreshToken,
+		ExpiresIn:	 s.ExpiresIn,
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)
@@ -156,4 +157,20 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 		Scopes: []string{ScopeUserReadEmail, ScopeUserReadPrivate},
 	}
 	return c
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -4,10 +4,10 @@ package spotify
 
 import (
 	"encoding/json"
-	"io"
-	"net/http"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"io"
+	"net/http"
 )
 
 const (
@@ -88,10 +88,10 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
-		AccessToken: s.AccessToken,
-		Provider:    p.Name(),
-		RefreshToken:s.RefreshToken,
-		ExpiresIn:	 s.ExpiresIn,
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+		ExpiresAt:    s.ExpiresAt,
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)
@@ -159,14 +159,14 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/twitch/session.go
+++ b/providers/twitch/session.go
@@ -3,17 +3,17 @@ package twitch
 import (
 	"encoding/json"
 	"errors"
-	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"time"
 )
 
 // Session stores data during the auth process with Twitch
 type Session struct {
-	AuthURL     string
-	AccessToken string
+	AuthURL      string
+	AccessToken  string
 	RefreshToken string
-	ExpiresIn    time.Time
+	ExpiresAt    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on
@@ -36,7 +36,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
-	s.ExpiresIn = token.Expiry
+	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/twitch/session.go
+++ b/providers/twitch/session.go
@@ -3,7 +3,7 @@ package twitch
 import (
 	"encoding/json"
 	"errors"
-
+	"time"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -12,6 +12,8 @@ import (
 type Session struct {
 	AuthURL     string
 	AccessToken string
+	RefreshToken string
+	ExpiresIn    time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on
@@ -33,6 +35,8 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 
 	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresIn = token.Expiry
 	return token.AccessToken, err
 }
 

--- a/providers/twitch/session_test.go
+++ b/providers/twitch/session_test.go
@@ -34,5 +34,5 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
 }

--- a/providers/twitch/session_test.go
+++ b/providers/twitch/session_test.go
@@ -34,5 +34,5 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresIn":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 }

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -4,12 +4,12 @@ package twitch
 
 import (
 	"encoding/json"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -98,10 +98,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 
 	user := goth.User{
-		AccessToken: s.AccessToken,
-		Provider:    p.Name(),
-		RefreshToken:s.RefreshToken,
-		ExpiresIn:s.ExpiresIn,
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+		ExpiresAt:    s.ExpiresAt,
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)
@@ -179,14 +179,14 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//Refresh token is provided by auth provider or not
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//Get new access token based on the refresh token
+//RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
-	token := &oauth2.Token{RefreshToken:refreshToken}
+	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 )
@@ -101,6 +100,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
+		RefreshToken:s.RefreshToken,
+		ExpiresIn:s.ExpiresIn,
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)
@@ -176,4 +177,20 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	}
 
 	return c
+}
+
+//Refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return true
+}
+
+//Get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken:refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
 }

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -5,12 +5,12 @@ package twitter
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
-	"strings"
-	"golang.org/x/oauth2"
+	"errors"
 	"github.com/markbates/goth"
 	"github.com/mrjones/oauth"
-	"errors"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"strings"
 )
 
 var (
@@ -132,13 +132,12 @@ func newConsumer(provider *Provider, authURL string) *oauth.Consumer {
 	return c
 }
 
-//refresh token is not provided by twitter
+//RefreshToken refresh token is not provided by twitter
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by twitter")
 }
 
-//refresh token is not provided by twitter
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by twitter
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }
-

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -7,9 +7,10 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"strings"
-
+	"golang.org/x/oauth2"
 	"github.com/markbates/goth"
 	"github.com/mrjones/oauth"
+	"errors"
 )
 
 var (
@@ -130,3 +131,14 @@ func newConsumer(provider *Provider, authURL string) *oauth.Consumer {
 	c.Debug(provider.debug)
 	return c
 }
+
+//refresh token is not provided by twitter
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by twitter")
+}
+
+//refresh token is not provided by twitter
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
+}
+

--- a/providers/yammer/session.go
+++ b/providers/yammer/session.go
@@ -3,11 +3,11 @@ package yammer
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"github.com/markbates/goth"
 	"io"
 	"io/ioutil"
-	"github.com/markbates/goth"
 	"net/http"
-	"fmt"
 	"net/url"
 	"strings"
 )
@@ -18,7 +18,6 @@ type Session struct {
 	AccessToken string
 	userMap     map[string]interface{} //stores yammer user detail in map
 }
-
 
 var _ goth.Session = &Session{}
 
@@ -35,7 +34,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	p := provider.(*Provider)
 	v := url.Values{
 		"grant_type":   {"authorization_code"},
-		"code":        CondVal(params.Get("code")),
+		"code":         CondVal(params.Get("code")),
 		"redirect_uri": CondVal(p.config.RedirectURL),
 		"scope":        CondVal(strings.Join(p.config.Scopes, " ")),
 	}
@@ -93,12 +92,13 @@ func retrieveAuthData(ClientID, ClientSecret, TokenURL string, v url.Values) (ma
 
 	err = json.Unmarshal(body, &objmap)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 	return objmap, nil
 }
 
+//CondVal convert string in string array
 func CondVal(v string) []string {
 	if v == "" {
 		return nil

--- a/providers/yammer/session_test.go
+++ b/providers/yammer/session_test.go
@@ -1,10 +1,10 @@
 package yammer_test
 
 import (
-	"testing"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/yammer"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_Implements_Session(t *testing.T) {

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 	"strconv"
+	"errors"
 )
 
 const (
@@ -103,4 +104,14 @@ func stringValue(v interface{}) string {
 		return ""
 	}
 	return v.(string)
+}
+
+//refresh token is not provided by yammer
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by yammer")
+}
+
+//refresh token is not provided by yammer
+func (p *Provider) RefreshTokenAvailable() (bool) {
+	return false
 }

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -4,17 +4,17 @@ package yammer
 
 import (
 	"encoding/json"
-	"strings"
+	"errors"
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
 	"strconv"
-	"errors"
+	"strings"
 )
 
 const (
-	authURL            string = "https://www.yammer.com/oauth2/authorize"
-	tokenURL           string = "https://www.yammer.com/oauth2/access_token"
-	endpointProfile    string = "https://api.yammer.com/user/profile"
+	authURL         string = "https://www.yammer.com/oauth2/authorize"
+	tokenURL        string = "https://www.yammer.com/oauth2/access_token"
+	endpointProfile string = "https://api.yammer.com/user/profile"
 )
 
 // Provider is the implementation of `goth.Provider` for accessing Yammer.
@@ -63,6 +63,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	err := populateUser(sess.userMap, &user)
 	return user, err
 }
+
 // UnmarshalSession wil unmarshal a JSON string into a session.
 func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 	s := &Session{}
@@ -93,7 +94,7 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 func populateUser(userMap map[string]interface{}, user *goth.User) error {
 	user.Email = stringValue(userMap["email"])
 	user.Name = stringValue(userMap["full_name"])
-	user.NickName =stringValue(userMap["full_name"])
+	user.NickName = stringValue(userMap["full_name"])
 	user.UserID = strconv.FormatFloat(userMap["id"].(float64), 'f', -1, 64)
 	user.Location = stringValue(userMap["location"])
 	return nil
@@ -106,12 +107,12 @@ func stringValue(v interface{}) string {
 	return v.(string)
 }
 
-//refresh token is not provided by yammer
+//RefreshToken refresh token is not provided by yammer
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by yammer")
 }
 
-//refresh token is not provided by yammer
-func (p *Provider) RefreshTokenAvailable() (bool) {
+//RefreshTokenAvailable refresh token is not provided by yammer
+func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/yammer/yammer_test.go
+++ b/providers/yammer/yammer_test.go
@@ -1,11 +1,11 @@
 package yammer_test
 
 import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/yammer"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"github.com/markbates/goth"
-	"github.com/stretchr/testify/assert"
-	"github.com/markbates/goth/providers/yammer"
 )
 
 func Test_New(t *testing.T) {
@@ -23,7 +23,6 @@ func Test_Implements_Provider(t *testing.T) {
 	a := assert.New(t)
 	a.Implements((*goth.Provider)(nil), provider())
 }
-
 
 func Test_BeginAuth(t *testing.T) {
 	t.Parallel()

--- a/user.go
+++ b/user.go
@@ -24,5 +24,5 @@ type User struct {
 	AccessToken       string
 	AccessTokenSecret string
 	RefreshToken      string
-	ExpiresIn         time.Time
+	ExpiresAt         time.Time
 }

--- a/user.go
+++ b/user.go
@@ -1,6 +1,9 @@
 package goth
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+	"time"
+)
 
 func init() {
 	gob.Register(User{})
@@ -20,4 +23,6 @@ type User struct {
 	Location          string
 	AccessToken       string
 	AccessTokenSecret string
+	RefreshToken      string
+	ExpiresIn         time.Time
 }


### PR DESCRIPTION
Hi Mark,
I have Added Refresh Token/Expiry Date of Access Token for applicable providers. There is a change in provider interface where we have additional methods :

- RefreshToken(refreshToken string) (*oauth2.Token, error) //Get new access token based on the refresh token
- RefreshTokenAvailable()(bool) //Refresh token is provided by auth provider or not

I have implemented and tested these for all existing providers.

Kindly review and see if we can merge it to the master.

Thanks,
Rakesh Goyal

