### PR TITLE
Add new Login provider "Steam" (OpenID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ go get github.com/markbates/goth
 * SalesForce
 * Slack
 * Spotify
+* Steam
 * Stripe
 * Twitch
 * Twitter

--- a/examples/main.go
+++ b/examples/main.go
@@ -26,13 +26,13 @@ import (
 	"github.com/markbates/goth/providers/salesforce"
 	"github.com/markbates/goth/providers/slack"
 	"github.com/markbates/goth/providers/spotify"
+	"github.com/markbates/goth/providers/steam"
 	"github.com/markbates/goth/providers/stripe"
 	"github.com/markbates/goth/providers/twitch"
 	"github.com/markbates/goth/providers/twitter"
 	"github.com/markbates/goth/providers/wepay"
 	"github.com/markbates/goth/providers/yahoo"
 	"github.com/markbates/goth/providers/yammer"
-	"github.com/markbates/goth/providers/steam"
 )
 
 func init() {
@@ -115,12 +115,12 @@ var indexTemplate = `
 <p><a href="/auth/salesforce">Log in with Salesforce</a></p>
 <p><a href="/auth/slack">Log in with Slack</a></p>
 <p><a href="/auth/spotify">Log in with Spotify</a></p>
+<p><a href="/auth/steam">Log in with Steam</a></p>
 <p><a href="/auth/stripe">Log in with Stripe</a></p>
 <p><a href="/auth/twitch">Log in with Twitch</a></p>
 <p><a href="/auth/wepay">Log in with Wepay</a></p>
 <p><a href="/auth/yahoo">Log in with Yahoo</a></p>
-<p><a href="/auth/yammer">Log in with Yammer</a></p>
-<p><a href="/auth/steam">Log in with Steam</a></p>`
+<p><a href="/auth/yammer">Log in with Yammer</a></p>`
 
 var userTemplate = `
 <p>Name: {{.Name}}</p>

--- a/examples/main.go
+++ b/examples/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/markbates/goth/providers/amazon"
 	"github.com/markbates/goth/providers/yammer"
 	"github.com/markbates/goth/providers/onedrive"
+	"github.com/markbates/goth/providers/steam"
 )
 
 func init() {
@@ -55,8 +56,7 @@ func main() {
 		amazon.New(os.Getenv("AMAZON_KEY"), os.Getenv("AMAZON_SECRET"), "http://localhost:3000/auth/amazon/callback"),
 		yammer.New(os.Getenv("YAMMER_KEY"), os.Getenv("YAMMER_SECRET"), "http://localhost:3000/auth/yammer/callback"),
 		onedrive.New(os.Getenv("ONEDRIVE_KEY"), os.Getenv("ONEDRIVE_SECRET"), "http://localhost:3000/auth/onedrive/callback"),
-
-
+		steam.New(os.Getenv("STEAM_KEY"), "http://localhost:3000/auth/steam/callback"),
 	)
 
 	p := pat.New()
@@ -101,6 +101,7 @@ var indexTemplate = `
 <p><a href="/auth/amazon">Log in with Amazon</a></p>
 <p><a href="/auth/yammer">Log in with Yammer</a></p>
 <p><a href="/auth/onedrive">Log in with Onedrive</a></p>
+<p><a href="/auth/steam">Log in with Steam</a></p>
 `
 
 var userTemplate = `

--- a/examples/main.go
+++ b/examples/main.go
@@ -32,11 +32,7 @@ import (
 	"github.com/markbates/goth/providers/wepay"
 	"github.com/markbates/goth/providers/yahoo"
 	"github.com/markbates/goth/providers/yammer"
-<<<<<<< HEAD
-	"github.com/markbates/goth/providers/onedrive"
 	"github.com/markbates/goth/providers/steam"
-=======
->>>>>>> master
 )
 
 func init() {
@@ -114,10 +110,6 @@ var indexTemplate = `
 <p><a href="/auth/lastfm">Log in with LastFM</a></p>
 <p><a href="/auth/linkedin">Log in with Linkedin</a></p>
 <p><a href="/auth/onedrive">Log in with Onedrive</a></p>
-<<<<<<< HEAD
-<p><a href="/auth/steam">Log in with Steam</a></p>
-`
-=======
 <p><a href="/auth/paypal">Log in with Paypal</a></p>
 <p><a href="/auth/twitter">Log in with Twitter</a></p>
 <p><a href="/auth/salesforce">Log in with Salesforce</a></p>
@@ -127,8 +119,8 @@ var indexTemplate = `
 <p><a href="/auth/twitch">Log in with Twitch</a></p>
 <p><a href="/auth/wepay">Log in with Wepay</a></p>
 <p><a href="/auth/yahoo">Log in with Yahoo</a></p>
-<p><a href="/auth/yammer">Log in with Yammer</a></p>`
->>>>>>> master
+<p><a href="/auth/yammer">Log in with Yammer</a></p>
+<p><a href="/auth/steam">Log in with Steam</a></p>`
 
 var userTemplate = `
 <p>Name: {{.Name}}</p>

--- a/providers/steam/session.go
+++ b/providers/steam/session.go
@@ -1,0 +1,92 @@
+// Package steam implements the OpenID protocol for authenticating users through Steam.
+package steam
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/markbates/goth"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Session stores data during the auth process with Steam.
+type Session struct {
+	AuthURL       string
+	CallbackURL   string
+	SteamID       string
+	ResponseNonce string
+}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the Steam provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New("An AuthURL has not be set")
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with Steam and return the unique response_nonce by OpenID.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	if params.Get("openid.mode") != "id_res" {
+		return "", errors.New("Mode must equal to \"id_res\".")
+	}
+
+	if params.Get("openid.return_to") != s.CallbackURL {
+		return "", errors.New("The \"return_to url\" must match the url of current request.")
+	}
+
+	v := make(url.Values)
+	v.Set("openid.assoc_handle", params.Get("openid.assoc_handle"))
+	v.Set("openid.signed", params.Get("openid.signed"))
+	v.Set("openid.sig", params.Get("openid.sig"))
+	v.Set("openid.ns", params.Get("openid.ns"))
+
+	split := strings.Split(params.Get("openid.signed"), ",")
+	for _, item := range split {
+		v.Set("openid."+item, params.Get("openid."+item))
+	}
+	v.Set("openid.mode", "check_authentication")
+
+	resp, err := http.PostForm(apiLoginEndpoint, v)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	response := strings.Split(string(content), "\n")
+	if response[0] != "ns:"+openIDNs {
+		return "", errors.New("Wrong ns in the response.")
+	}
+
+	if response[1] == "is_valid:false" {
+		return "", errors.New("Unable validate openId.")
+	}
+
+	openIdUrl := params.Get("openid.claimed_id")
+	validationRegExp := regexp.MustCompile("^(http|https)://steamcommunity.com/openid/id/[0-9]{15,25}$")
+	if !validationRegExp.MatchString(openIdUrl) {
+		return "", errors.New("Invalid Steam ID pattern.")
+	}
+
+	s.SteamID = regexp.MustCompile("\\D+").ReplaceAllString(openIdUrl, "")
+	s.ResponseNonce = params.Get("openid.response_nonce")
+
+	return s.ResponseNonce, nil
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}

--- a/providers/steam/session.go
+++ b/providers/steam/session.go
@@ -69,13 +69,13 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", errors.New("Unable validate openId.")
 	}
 
-	openIdUrl := params.Get("openid.claimed_id")
+	openIDURL := params.Get("openid.claimed_id")
 	validationRegExp := regexp.MustCompile("^(http|https)://steamcommunity.com/openid/id/[0-9]{15,25}$")
-	if !validationRegExp.MatchString(openIdUrl) {
+	if !validationRegExp.MatchString(openIDURL) {
 		return "", errors.New("Invalid Steam ID pattern.")
 	}
 
-	s.SteamID = regexp.MustCompile("\\D+").ReplaceAllString(openIdUrl, "")
+	s.SteamID = regexp.MustCompile("\\D+").ReplaceAllString(openIDURL, "")
 	s.ResponseNonce = params.Get("openid.response_nonce")
 
 	return s.ResponseNonce, nil

--- a/providers/steam/session_test.go
+++ b/providers/steam/session_test.go
@@ -1,11 +1,10 @@
 package steam_test
 
 import (
-	"testing"
-
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/steam"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_Implements_Session(t *testing.T) {

--- a/providers/steam/session_test.go
+++ b/providers/steam/session_test.go
@@ -1,0 +1,48 @@
+package steam_test
+
+import (
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/steam"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Implements_Session(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &steam.Session{}
+
+	a.Implements((*goth.Session)(nil), s)
+}
+
+func Test_GetAuthURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &steam.Session{}
+
+	_, err := s.GetAuthURL()
+	a.Error(err)
+
+	s.AuthURL = "/foo"
+
+	url, _ := s.GetAuthURL()
+	a.Equal(url, "/foo")
+}
+
+func Test_ToJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &steam.Session{}
+
+	data := s.Marshal()
+	a.Equal(data, `{"AuthURL":"","CallbackURL":"","SteamID":"","ResponseNonce":""}`)
+}
+
+func Test_String(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &steam.Session{}
+
+	a.Equal(s.String(), s.Marshal())
+}

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -1,0 +1,174 @@
+// Package steam implements the OpenID protocol for authenticating users through Steam.
+package steam
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/markbates/goth"
+)
+
+const (
+	// Steam API Endpoints
+	apiLoginEndpoint       = "https://steamcommunity.com/openid/login"
+	apiUserSummaryEndpoint = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s"
+
+	// OpenID settings
+	openIDMode       = "checkid_setup"
+	openIDNs         = "http://specs.openid.net/auth/2.0"
+	openIDIdentifier = "http://specs.openid.net/auth/2.0/identifier_select"
+)
+
+// New creates a new Steam provider, and sets up important connection details.
+// You should always call `steam.New` to get a new Provider. Never try to create
+// one manually.
+func New(apiKey string, callbackURL string) *Provider {
+	p := &Provider{
+		APIKey:      apiKey,
+		CallbackURL: callbackURL,
+	}
+	return p
+}
+
+// Provider is the implementation of `goth.Provider` for accessing Steam
+type Provider struct {
+	APIKey      string
+	CallbackURL string
+}
+
+// Name gets the name used to retrieve this provider.
+func (p *Provider) Name() string {
+	return "steam"
+}
+
+// Debug is no-op for the Steam package.
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth will return the authentication end-point for Steam.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	u, err := p.getAuthUrl()
+	s := &Session{
+		AuthURL:     u.String(),
+		CallbackURL: p.CallbackURL,
+	}
+	return s, err
+}
+
+// getAuthUrl is an internal function to build the correct
+// authentication url to redirect the user to Steam.
+func (p *Provider) getAuthUrl() (*url.URL, error) {
+	callbackUrl, err := url.Parse(p.CallbackURL)
+	if err != nil {
+		return nil, err
+	}
+
+	urlValues := map[string]string{
+		"openid.claimed_id": openIDIdentifier,
+		"openid.identity":   openIDIdentifier,
+		"openid.mode":       openIDMode,
+		"openid.ns":         openIDNs,
+		"openid.realm":      fmt.Sprintf("%s://%s", callbackUrl.Scheme, callbackUrl.Host),
+		"openid.return_to":  callbackUrl.String(),
+	}
+
+	u, err := url.Parse(apiLoginEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	v := u.Query()
+	for key, value := range urlValues {
+		v.Set(key, value)
+	}
+	u.RawQuery = v.Encode()
+
+	return u, nil
+}
+
+// FetchUser will go to Steam and access basic info about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	s := session.(*Session)
+	u := goth.User{
+		Provider:    p.Name(),
+		AccessToken: s.ResponseNonce,
+	}
+
+	apiUrl := fmt.Sprintf(apiUserSummaryEndpoint, p.APIKey, s.SteamID)
+	req, err := http.NewRequest("GET", apiUrl, nil)
+	if err != nil {
+		return u, err
+	}
+	req.Header.Add("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return u, err
+	}
+	defer resp.Body.Close()
+	u, err = buildUserObject(resp.Body, u)
+
+	return u, err
+}
+
+// buildUserObject is an internal function to build a goth.User object
+// based in the data stored in r
+func buildUserObject(r io.Reader, u goth.User) (goth.User, error) {
+	// Response object from Steam
+	apiResponse := struct {
+		Response struct {
+			Players []struct {
+				UserID              string `json:"steamid"`
+				NickName            string `json:"personaname"`
+				Name                string `json:"realname"`
+				AvatarURL           string `json:"avatarfull"`
+				LocationCountryCode string `json:"loccountrycode"`
+				LocationStateCode   string `json:"locstatecode"`
+			} `json:"players"`
+		} `json:"response"`
+	}{}
+
+	err := json.NewDecoder(r).Decode(&apiResponse)
+	if err != nil {
+		return u, err
+	}
+
+	if l := len(apiResponse.Response.Players); l != 1 {
+		return u, fmt.Errorf("Expected one player in API response. Got %d.", l)
+	}
+
+	player := apiResponse.Response.Players[0]
+	u.UserID = player.UserID
+	u.Name = player.Name
+	if len(player.Name) == 0 {
+		u.Name = "No name is provided by the Steam API"
+	}
+	u.NickName = player.NickName
+	u.AvatarURL = player.AvatarURL
+	u.Email = "No email is provided by the Steam API"
+	u.Description = "No description is provided by the Steam API"
+
+	if len(player.LocationStateCode) > 0 && len(player.LocationCountryCode) > 0 {
+		u.Location = fmt.Sprintf("%s, %s", player.LocationStateCode, player.LocationCountryCode)
+	} else if len(player.LocationCountryCode) > 0 {
+		u.Location = player.LocationCountryCode
+	} else if len(player.LocationStateCode) > 0 {
+		u.Location = player.LocationStateCode
+	} else {
+		u.Location = "No location is provided by the Steam API"
+	}
+
+	return u, nil
+}
+
+// UnmarshalSession will unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	s := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(s)
+	return s, err
+}

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -171,4 +172,14 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 	s := &Session{}
 	err := json.NewDecoder(strings.NewReader(data)).Decode(s)
 	return s, err
+}
+
+// RefreshToken refresh token is not provided by Steam
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, nil
+}
+
+// RefreshTokenAvailable refresh token is not provided by Steam
+func (p *Provider) RefreshTokenAvailable() bool {
+	return false
 }

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -4,13 +4,12 @@ package steam
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
-
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -51,7 +50,7 @@ func (p *Provider) Debug(debug bool) {}
 
 // BeginAuth will return the authentication end-point for Steam.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
-	u, err := p.getAuthUrl()
+	u, err := p.getAuthURL()
 	s := &Session{
 		AuthURL:     u.String(),
 		CallbackURL: p.CallbackURL,
@@ -59,10 +58,10 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	return s, err
 }
 
-// getAuthUrl is an internal function to build the correct
+// getAuthURL is an internal function to build the correct
 // authentication url to redirect the user to Steam.
-func (p *Provider) getAuthUrl() (*url.URL, error) {
-	callbackUrl, err := url.Parse(p.CallbackURL)
+func (p *Provider) getAuthURL() (*url.URL, error) {
+	callbackURL, err := url.Parse(p.CallbackURL)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +71,8 @@ func (p *Provider) getAuthUrl() (*url.URL, error) {
 		"openid.identity":   openIDIdentifier,
 		"openid.mode":       openIDMode,
 		"openid.ns":         openIDNs,
-		"openid.realm":      fmt.Sprintf("%s://%s", callbackUrl.Scheme, callbackUrl.Host),
-		"openid.return_to":  callbackUrl.String(),
+		"openid.realm":      fmt.Sprintf("%s://%s", callbackURL.Scheme, callbackURL.Host),
+		"openid.return_to":  callbackURL.String(),
 	}
 
 	u, err := url.Parse(apiLoginEndpoint)
@@ -98,8 +97,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: s.ResponseNonce,
 	}
 
-	apiUrl := fmt.Sprintf(apiUserSummaryEndpoint, p.APIKey, s.SteamID)
-	req, err := http.NewRequest("GET", apiUrl, nil)
+	apiURL := fmt.Sprintf(apiUserSummaryEndpoint, p.APIKey, s.SteamID)
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return u, err
 	}

--- a/providers/steam/steam_test.go
+++ b/providers/steam/steam_test.go
@@ -1,0 +1,54 @@
+package steam_test
+
+import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/steam"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+
+	a.Equal(p.APIKey, os.Getenv("STEAM_KEY"))
+	a.Equal(p.CallbackURL, "/foo")
+}
+
+func Test_Implements_Provider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	a.Implements((*goth.Provider)(nil), provider())
+}
+
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*steam.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "steamcommunity.com/openid/login")
+	a.Contains(s.AuthURL, "foo")
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	p := provider()
+	session, err := p.UnmarshalSession(`{"AuthURL":"https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.realm=%3A%2F%2F&openid.return_to=%2Ffoo","SteamID":"1234567890","CallbackURL":"http://localhost:3030/","ResponseNonce":"2016-03-13T16:56:30ZJ8tlKVquwHi9ZSPV4ElU5PY2dmI="}`)
+	a.NoError(err)
+
+	s := session.(*steam.Session)
+	a.Equal(s.AuthURL, "https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.realm=%3A%2F%2F&openid.return_to=%2Ffoo")
+	a.Equal(s.CallbackURL, "http://localhost:3030/")
+	a.Equal(s.SteamID, "1234567890")
+	a.Equal(s.ResponseNonce, "2016-03-13T16:56:30ZJ8tlKVquwHi9ZSPV4ElU5PY2dmI=")
+}
+
+func provider() *steam.Provider {
+	return steam.New(os.Getenv("STEAM_KEY"), "/foo")
+}


### PR DESCRIPTION
Steam (http://store.steampowered.com/) can act as an OpenID provider.
See http://steamcommunity.com/dev

This PR is a implementation of the OpenID for Steam.