### PR TITLE
Use login name as nickname for GitHub provider

### DIFF
--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -96,6 +96,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		Email    string `json:"email"`
 		Bio      string `json:"bio"`
 		Name     string `json:"name"`
+		Login    string `json:"login"`
 		Picture  string `json:"avatar_url"`
 		Location string `json:"location"`
 	}{}
@@ -106,7 +107,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 	}
 
 	user.Name = u.Name
-	user.NickName = u.Name
+	user.NickName = u.Login
 	user.Email = u.Email
 	user.Description = u.Bio
 	user.AvatarURL = u.Picture


### PR DESCRIPTION
Would close #72 if merged

The `nickname` field for GitHub previously used the user's name. It was suggested that the nickname field could be used to store the user's login instead, which seems like a good idea. Tested this quickly on my local machine with the GitHub API as well to make sure this didn't break anything.