### PR TITLE
Updated spotify Authorize function to point to Session

### DIFF
--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -27,7 +27,7 @@ func (s Session) GetAuthURL() (string, error) {
 
 // Authorize completes the the authorization with Spotify and returns the access
 // token to be stored for future use.
-func (s Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
 	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
 	if err != nil {

--- a/providers/spotify/session_test.go
+++ b/providers/spotify/session_test.go
@@ -1,23 +1,24 @@
-package spotify
+package spotify_test
 
 import (
 	"testing"
 
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/spotify"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_ImplementsSession(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := Session{}
+	s := &spotify.Session{}
 	a.Implements((*goth.Session)(nil), s)
 }
 
 func Test_GetAuthURL(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &Session{}
+	s := &spotify.Session{}
 
 	_, err := s.GetAuthURL()
 	a.Error(err)
@@ -30,7 +31,7 @@ func Test_GetAuthURL(t *testing.T) {
 func Test_ToJSON(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &Session{}
+	s := &spotify.Session{}
 
 	data := s.Marshal()
 	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -149,6 +149,18 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 		},
 		Scopes: []string{ScopeUserReadEmail, ScopeUserReadPrivate},
 	}
+
+	defaultScopes := map[string]struct{}{
+		ScopeUserReadEmail: {},
+		ScopeUserReadPrivate: {},
+	}
+
+	for _, scope := range scopes {
+		if _, exists := defaultScopes[scope]; !exists {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	}
+
 	return c
 }
 

--- a/providers/spotify/spotify_test.go
+++ b/providers/spotify/spotify_test.go
@@ -1,15 +1,16 @@
-package spotify
+package spotify_test
 
 import (
 	"os"
 	"testing"
 
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/spotify"
 	"github.com/stretchr/testify/assert"
 )
 
-func provider() *Provider {
-	return New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "/foo", "user")
+func provider() *spotify.Provider {
+	return spotify.New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "/foo", "user")
 }
 
 func Test_New(t *testing.T) {
@@ -34,7 +35,7 @@ func Test_BeginAuth(t *testing.T) {
 
 	p := provider()
 	session, err := p.BeginAuth("test_state")
-	s := session.(*Session)
+	s := session.(*spotify.Session)
 	a.NoError(err)
 	a.Contains(s.AuthURL, "accounts.spotify.com/authorize")
 }
@@ -47,7 +48,7 @@ func Test_SessionFromJSON(t *testing.T) {
 	session, err := p.UnmarshalSession(`{"AuthURL":"http://accounts.spotify.com/authorize","AccessToken":"1234567890"}`)
 	a.NoError(err)
 
-	s := session.(*Session)
+	s := session.(*spotify.Session)
 	a.Equal(s.AuthURL, "http://accounts.spotify.com/authorize")
 	a.Equal(s.AccessToken, "1234567890")
 }


### PR DESCRIPTION
session "s" was not referenced properly so it's variables were not being set as expected after authorization.