### PR TITLE
Validate tokens from provider during the Authorize() call

### DIFF
--- a/providers/amazon/session.go
+++ b/providers/amazon/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/bitbucket/session.go
+++ b/providers/bitbucket/session.go
@@ -32,6 +32,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/box/session.go
+++ b/providers/box/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/digitalocean/session.go
+++ b/providers/digitalocean/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -106,6 +106,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.Token = token.AccessToken
 	return token.AccessToken, nil
 }

--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -31,6 +31,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err

--- a/providers/github/session.go
+++ b/providers/github/session.go
@@ -30,6 +30,10 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	return token.AccessToken, err
 }

--- a/providers/gitlab/session.go
+++ b/providers/gitlab/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -32,6 +32,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/heroku/session.go
+++ b/providers/heroku/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/instagram/session.go
+++ b/providers/instagram/session.go
@@ -29,6 +29,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	return token.AccessToken, err
 }

--- a/providers/lastfm/session.go
+++ b/providers/lastfm/session.go
@@ -30,10 +30,6 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 
-	if !token.Valid() {
-		return "", errors.New("Invalid token received from provider")
-	}
-
 	s.AccessToken = sess["token"]
 	s.Login = sess["login"]
 	return sess["token"], err

--- a/providers/lastfm/session.go
+++ b/providers/lastfm/session.go
@@ -29,6 +29,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = sess["token"]
 	s.Login = sess["login"]
 	return sess["token"], err

--- a/providers/linkedin/session.go
+++ b/providers/linkedin/session.go
@@ -30,6 +30,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.ExpiresAt = token.Expiry
 	return token.AccessToken, err

--- a/providers/onedrive/session.go
+++ b/providers/onedrive/session.go
@@ -35,6 +35,10 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/paypal/session.go
+++ b/providers/paypal/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/salesforce/session.go
+++ b/providers/salesforce/session.go
@@ -43,6 +43,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ID = token.Extra("id").(string) //Required to get the user info from sales force

--- a/providers/slack/session.go
+++ b/providers/slack/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/soundcloud/session.go
+++ b/providers/soundcloud/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -33,6 +33,11 @@ func (s Session) Authorize(provider goth.Provider, params goth.Params) (string, 
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/stripe/session.go
+++ b/providers/stripe/session.go
@@ -35,6 +35,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/twitch/session.go
+++ b/providers/twitch/session.go
@@ -35,6 +35,10 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/twitter/session.go
+++ b/providers/twitter/session.go
@@ -30,6 +30,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = accessToken
 	return accessToken.Token, err
 }

--- a/providers/twitter/session.go
+++ b/providers/twitter/session.go
@@ -31,10 +31,6 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 
-	if !token.Valid() {
-		return "", errors.New("Invalid token received from provider")
-	}
-
 	s.AccessToken = accessToken
 	return accessToken.Token, err
 }

--- a/providers/uber/session.go
+++ b/providers/uber/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/wepay/session.go
+++ b/providers/wepay/session.go
@@ -35,6 +35,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry

--- a/providers/yahoo/session.go
+++ b/providers/yahoo/session.go
@@ -34,6 +34,11 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry


### PR DESCRIPTION
Addresses #78 by updating all providers using the oauth2 framework to validate the tokens they receive from the provider, and throw an error if the token is invalid.