### PR TITLE
Added a 'cloudfoundry' OAuth2 provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ go get github.com/markbates/goth
 * Amazon
 * Bitbucket
 * Box
+* Cloud Foundry
 * Digital Ocean
 * Dropbox
 * Facebook

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -1,0 +1,150 @@
+// Package cloudfoundry implements the OAuth2 protocol for authenticating users through Cloud Foundry
+// This package can be used as a reference implementation of an OAuth2 provider for Goth.
+package cloudfoundry
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/markbates/goth"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Provider is the implementation of `goth.Provider` for accessing Cloud Foundry.
+type Provider struct {
+	AuthURL     string
+	TokenURL    string
+	UserInfoURL string
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Client      *http.Client
+	config      *oauth2.Config
+}
+
+// New creates a new Cloud Foundry provider and sets up important connection details.
+// You should always call `cloudfoundry.New` to get a new provider.  Never try to
+// create one manually.
+func New(uaaURL, clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	uaaURL = strings.TrimSuffix(uaaURL, "/")
+	p := &Provider{
+		ClientKey:   clientKey,
+		Secret:      secret,
+		CallbackURL: callbackURL,
+		AuthURL:     uaaURL + "/oauth/authorize",
+		TokenURL:    uaaURL + "/oauth/token",
+		UserInfoURL: uaaURL + "/userinfo",
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Name is the name used to retrieve this provider later.
+func (p *Provider) Name() string {
+	return "cloudfoundry"
+}
+
+// Debug is a no-op for the cloudfoundry package.
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks Cloud Foundry for an authentication end-point.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	return &Session{
+		AuthURL: p.config.AuthCodeURL(state),
+	}, nil
+}
+
+// FetchUser will go to Cloud Foundry and access basic information about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	s := session.(*Session)
+	user := goth.User{
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+		ExpiresAt:    s.ExpiresAt,
+	}
+	req, err := http.NewRequest("GET", p.UserInfoURL, nil)
+	if err != nil {
+		return user, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return user, err
+	}
+	defer resp.Body.Close()
+
+	bits, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return user, err
+	}
+
+	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&user.RawData)
+	if err != nil {
+		return user, err
+	}
+
+	err = userFromReader(bytes.NewReader(bits), &user)
+	return user, err
+}
+
+func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     provider.ClientKey,
+		ClientSecret: provider.Secret,
+		RedirectURL:  provider.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  provider.AuthURL,
+			TokenURL: provider.TokenURL,
+		},
+		Scopes: []string{},
+	}
+
+	if len(scopes) > 0 {
+		for _, scope := range scopes {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	}
+	return c
+}
+
+func userFromReader(r io.Reader, user *goth.User) error {
+	u := struct {
+		Name  string `json:"user_name"`
+		Email string `json:"email"`
+		ID    string `json:"user_id"`
+	}{}
+	err := json.NewDecoder(r).Decode(&u)
+	if err != nil {
+		return err
+	}
+	user.Name = u.Name
+	user.NickName = u.Name
+	user.UserID = u.ID
+	user.Email = u.Email
+	return nil
+}
+
+//RefreshTokenAvailable refresh token is provided by auth provider or not
+func (p *Provider) RefreshTokenAvailable() bool {
+	return true
+}
+
+//RefreshToken get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken: refreshToken}
+	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, p.Client)
+	ts := p.config.TokenSource(ctx, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
+}

--- a/providers/cloudfoundry/cf_test.go
+++ b/providers/cloudfoundry/cf_test.go
@@ -1,0 +1,52 @@
+package cloudfoundry_test
+
+import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/cloudfoundry"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+
+	a.Equal(p.ClientKey, os.Getenv("UAA_CLIENT_ID"))
+	a.Equal(p.Secret, os.Getenv("UAA_CLIENT_SECRET"))
+	a.Equal(p.CallbackURL, "/foo")
+}
+
+func Test_Implements_Provider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	a.Implements((*goth.Provider)(nil), provider())
+}
+
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*cloudfoundry.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "https://cf.example.com/oauth/authorize")
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	p := provider()
+	session, err := p.UnmarshalSession(`{"AuthURL":"https://cf.example.com/oauth/authorize","AccessToken":"1234567890"}`)
+	a.NoError(err)
+
+	s := session.(*cloudfoundry.Session)
+	a.Equal(s.AuthURL, "https://cf.example.com/oauth/authorize")
+	a.Equal(s.AccessToken, "1234567890")
+}
+
+func provider() *cloudfoundry.Provider {
+	return cloudfoundry.New("https://cf.example.com/", os.Getenv("UAA_CLIENT_ID"), os.Getenv("UAA_CLIENT_SECRET"), "/foo")
+}

--- a/providers/cloudfoundry/session.go
+++ b/providers/cloudfoundry/session.go
@@ -1,0 +1,67 @@
+package cloudfoundry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/markbates/goth"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"strings"
+	"time"
+)
+
+// Session stores data during the auth process with Box.
+type Session struct {
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+var _ goth.Session = &Session{}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New("an AuthURL has not be set")
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with Cloud Foundry and return the access token to be stored for future use.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, p.Client)
+	token, err := p.config.Exchange(ctx, params.Get("code"))
+	if err != nil {
+		return "", err
+	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
+	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresAt = token.Expiry
+	fmt.Printf("TOKEN: %s\n", s.AccessToken)
+	return token.AccessToken, err
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}
+
+// UnmarshalSession wil unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	s := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(s)
+	return s, err
+}

--- a/providers/cloudfoundry/session_test.go
+++ b/providers/cloudfoundry/session_test.go
@@ -1,0 +1,47 @@
+package cloudfoundry_test
+
+import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/cloudfoundry"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Implements_Session(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &cloudfoundry.Session{}
+
+	a.Implements((*goth.Session)(nil), s)
+}
+
+func Test_GetAuthURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &cloudfoundry.Session{}
+
+	_, err := s.GetAuthURL()
+	a.Error(err)
+
+	s.AuthURL = "/foo"
+
+	url, _ := s.GetAuthURL()
+	a.Equal(url, "/foo")
+}
+
+func Test_ToJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &cloudfoundry.Session{}
+
+	data := s.Marshal()
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
+}
+
+func Test_String(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &cloudfoundry.Session{}
+
+	a.Equal(s.String(), s.Marshal())
+}


### PR DESCRIPTION
It works much the same as the other OAuth2 providers. However, since
Cloud Foundry isn't typically a hosted service, the UAA base URL
is configurable, to match that of your Cloud Foundry installation's
UAA.