### PR TITLE
Find provider in mux vars

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
 )
@@ -176,6 +177,10 @@ func getProviderName(req *http.Request) (string, error) {
 	provider := req.URL.Query().Get("provider")
 	if provider == "" {
 		provider = req.URL.Query().Get(":provider")
+	}
+	if provider == "" {
+		muxVars := mux.Vars(req)
+		provider = muxVars["provider"]
 	}
 	if provider == "" {
 		return provider, errors.New("you must select a provider")


### PR DESCRIPTION
I am using mux router, and Query().Get("provider") is always empty. So I added a check in mux Vars.