### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -15,10 +15,17 @@ import (
 	"strconv"
 )
 
-const (
-	authURL         string = "https://github.com/login/oauth/authorize"
-	tokenURL        string = "https://github.com/login/oauth/access_token"
-	endpointProfile string = "https://api.github.com/user"
+// These vars define the Authentication, Token, and API URLS for GitHub. If
+// using GitHub enterprise you should change these values before calling New.
+//
+// Examples:
+//	github.AuthURL = "https://github.acme.com/login/oauth/authorize
+//	github.TokenURL = "https://github.acme.com/login/oauth/access_token
+//	github.ProfileURL = "https://github.acme.com/api/v3/user
+var (
+	AuthURL    = "https://github.com/login/oauth/authorize"
+	TokenURL   = "https://github.com/login/oauth/access_token"
+	ProfileURL = "https://api.github.com/user"
 )
 
 // New creates a new Github provider, and sets up important connection details.
@@ -67,7 +74,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := http.Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -123,8 +130,8 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 		ClientSecret: provider.Secret,
 		RedirectURL:  provider.CallbackURL,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  authURL,
-			TokenURL: tokenURL,
+			AuthURL:  AuthURL,
+			TokenURL: TokenURL,
 		},
 		Scopes: []string{},
 	}


### PR DESCRIPTION
One of my clients wants to add GitHub authentication to their site but they use a hosted version which is not at github.com. The GitHub provider in this package uses hard coded URLs for authentication, tokens, and the API and they are not exposed in a way I can change them from another package.

I created a func `NewEnterprise` which wraps around `New` but changes the urls before returning. I also added a field to `Provider` of the URL to use when fetching the user profile.

I couldn't see a reasonable way of testing that `NewEnterprise` sets the token url appropriately so I didn't. If you can think of any changes you would like I'd be happy to make them.