### PR TITLE
Replace direct usage of http.DefaultClient in providers and oauth2 calls

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -1,7 +1,12 @@
 package goth
 
-import "fmt"
-import "golang.org/x/oauth2"
+import (
+	"fmt"
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+)
 
 // Provider needs to be implemented for each 3rd party authentication provider
 // e.g. Facebook, Twitter, etc...
@@ -46,4 +51,20 @@ func GetProvider(name string) (Provider, error) {
 // This is useful, mostly, for testing purposes.
 func ClearProviders() {
 	providers = Providers{}
+}
+
+// ContextForClient provides a context for use with oauth2.
+func ContextForClient(h *http.Client) context.Context {
+	if h == nil {
+		return oauth2.NoContext
+	}
+	return context.WithValue(oauth2.NoContext, oauth2.HTTPClient, h)
+}
+
+// HTTPClientWithFallBack to be used in all fetch operations.
+func HTTPClientWithFallBack(h *http.Client) *http.Client {
+	if h != nil {
+		return h
+	}
+	return http.DefaultClient
 }

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -5,12 +5,13 @@ package amazon
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -24,6 +25,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -65,7 +67,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -137,7 +139,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/amazon/session.go
+++ b/providers/amazon/session.go
@@ -3,10 +3,10 @@ package amazon
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Amazon and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -4,12 +4,13 @@ package bitbucket
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -37,6 +38,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -67,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -88,7 +90,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	err = userFromReader(bytes.NewReader(bits), &user)
 
-	response, err = http.Get(endpointEmail + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err = goth.HTTPClientWithFallBack(p.Client).Get(endpointEmail + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -180,7 +182,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/bitbucket/session.go
+++ b/providers/bitbucket/session.go
@@ -3,10 +3,10 @@ package bitbucket
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Bitbucket.
@@ -28,7 +28,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Bitbucket and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -4,10 +4,11 @@ package box
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -22,6 +23,7 @@ type Provider struct {
 	Secret      string
 	CallbackURL string
 	config      *oauth2.Config
+	Client      *http.Client
 }
 
 // New creates a new Box provider and sets up important connection details.
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -128,7 +130,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/box/session.go
+++ b/providers/box/session.go
@@ -3,10 +3,10 @@ package box
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Box and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -5,13 +5,14 @@ package cloudfoundry
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/net/context"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/markbates/goth"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
 )
 
 // Provider is the implementation of `goth.Provider` for accessing Cloud Foundry.
@@ -72,7 +73,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := p.Client.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -140,7 +141,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, p.Client)
+	ctx := context.WithValue(goth.ContextForClient(p.Client), oauth2.HTTPClient, goth.HTTPClientWithFallBack(p.Client))
 	ts := p.config.TokenSource(ctx, token)
 	newToken, err := ts.Token()
 	if err != nil {

--- a/providers/cloudfoundry/session.go
+++ b/providers/cloudfoundry/session.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/markbates/goth"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
-	"strings"
-	"time"
 )
 
 // Session stores data during the auth process with Box.
@@ -32,7 +33,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Cloud Foundry and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, p.Client)
+	ctx := context.WithValue(goth.ContextForClient(p.Client), oauth2.HTTPClient, p.Client)
 	token, err := p.config.Exchange(ctx, params.Get("code"))
 	if err != nil {
 		return "", err

--- a/providers/digitalocean/session.go
+++ b/providers/digitalocean/session.go
@@ -3,10 +3,10 @@ package digitalocean
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with DigitalOcean.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with DigitalOcean and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -4,11 +4,12 @@ package dropbox
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -22,6 +23,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -71,7 +73,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -102,7 +104,7 @@ func (s *Session) GetAuthURL() (string, error) {
 // Authorize the session with Dropbox and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -6,12 +6,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -38,6 +39,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -67,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:   sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "&access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "&access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()

--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -3,10 +3,10 @@ package facebook
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Facebook.
@@ -27,7 +27,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Facebook and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -4,9 +4,10 @@ package faux
 
 import (
 	"encoding/json"
+	"strings"
+
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
-	"strings"
 )
 
 // Provider is used only for testing.

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -6,13 +6,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 // These vars define the Authentication, Token, and API URLS for GitHub. If
@@ -46,6 +47,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -74,7 +76,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()

--- a/providers/github/session.go
+++ b/providers/github/session.go
@@ -3,9 +3,9 @@ package github
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Github.
@@ -25,7 +25,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Github and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -5,13 +5,14 @@ package gitlab
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -25,6 +26,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -139,7 +141,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/gitlab/session.go
+++ b/providers/gitlab/session.go
@@ -3,10 +3,10 @@ package gitlab
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Gitlab and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -39,6 +39,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 	prompt      oauth2.AuthCodeOption
 }
@@ -74,7 +75,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -152,7 +153,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -3,10 +3,10 @@ package gplus
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Facebook.
@@ -28,7 +28,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Google+ and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -4,10 +4,11 @@ package heroku
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -21,6 +22,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -123,7 +125,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/heroku/session.go
+++ b/providers/heroku/session.go
@@ -3,10 +3,10 @@ package heroku
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Heroku and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -42,6 +42,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -70,7 +71,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()

--- a/providers/influxcloud/session.go
+++ b/providers/influxcloud/session.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 )
 
 // Session stores data during the auth process with Github.
@@ -26,7 +25,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Github and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -37,6 +38,7 @@ type Provider struct {
 	Secret      string
 	CallbackURL string
 	UserAgent   string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -65,7 +67,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()

--- a/providers/instagram/session.go
+++ b/providers/instagram/session.go
@@ -3,9 +3,9 @@ package instagram
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Instagram
@@ -25,7 +25,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Instagram and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -8,12 +8,13 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sort"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 var (
@@ -39,6 +40,7 @@ type Provider struct {
 	Secret      string
 	CallbackURL string
 	UserAgent   string
+	Client      *http.Client
 }
 
 // Name is the name used to retrive this provider later.

--- a/providers/lastfm/session.go
+++ b/providers/lastfm/session.go
@@ -3,8 +3,9 @@ package lastfm
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
 	"strings"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Lastfm.

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -4,11 +4,12 @@ package linkedin
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 //more details about linkedin fields: https://developer.linkedin.com/documents/profile-fields
@@ -39,6 +40,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -82,7 +84,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
 	req.Header.Add("x-li-format", "json") //request json response
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()

--- a/providers/linkedin/session.go
+++ b/providers/linkedin/session.go
@@ -3,9 +3,9 @@ package linkedin
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Linkedin.
@@ -26,7 +26,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Linkedin and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -5,12 +5,13 @@ package onedrive
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -24,6 +25,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -65,7 +67,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -135,7 +137,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/onedrive/session.go
+++ b/providers/onedrive/session.go
@@ -3,10 +3,10 @@ package onedrive
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Box and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -5,13 +5,14 @@ package paypal
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -34,6 +35,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -85,7 +87,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		profileEndPoint = endpointProfileProduction
 	}
 
-	response, err := http.Get(profileEndPoint + "?schema=openid&access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(profileEndPoint + "?schema=openid&access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -173,7 +175,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/paypal/session.go
+++ b/providers/paypal/session.go
@@ -3,10 +3,10 @@ package paypal
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Paypal and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -4,11 +4,12 @@ package salesforce
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -23,6 +24,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -70,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -133,7 +135,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/salesforce/session.go
+++ b/providers/salesforce/session.go
@@ -3,9 +3,9 @@ package salesforce
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Salesforce.
@@ -38,7 +38,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Salesforce and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 
 	if err != nil {
 		return "", err

--- a/providers/slack/session.go
+++ b/providers/slack/session.go
@@ -3,10 +3,10 @@ package slack
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Slack and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/soundcloud/session.go
+++ b/providers/soundcloud/session.go
@@ -3,10 +3,10 @@ package soundcloud
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Soundcloud and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -5,13 +5,14 @@ package soundcloud
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -25,6 +26,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
-	response, err := http.Get(endpointProfile + "?oauth_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := goth.HTTPClientWithFallBack(p.Client).Get(endpointProfile + "?oauth_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -138,7 +140,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -3,9 +3,9 @@ package spotify
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Spotify.
@@ -29,7 +29,7 @@ func (s Session) GetAuthURL() (string, error) {
 // token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -4,10 +4,11 @@ package spotify
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -64,6 +65,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -99,7 +101,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -151,7 +153,7 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	}
 
 	defaultScopes := map[string]struct{}{
-		ScopeUserReadEmail: {},
+		ScopeUserReadEmail:   {},
 		ScopeUserReadPrivate: {},
 	}
 
@@ -172,7 +174,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/steam/session.go
+++ b/providers/steam/session.go
@@ -4,12 +4,13 @@ package steam
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Steam.

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -4,11 +4,12 @@ package steam
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -37,6 +38,7 @@ func New(apiKey string, callbackURL string) *Provider {
 type Provider struct {
 	APIKey      string
 	CallbackURL string
+	Client      *http.Client
 }
 
 // Name gets the name used to retrieve this provider.
@@ -102,7 +104,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return u, err
 	}
 	req.Header.Add("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()

--- a/providers/stripe/session.go
+++ b/providers/stripe/session.go
@@ -3,10 +3,10 @@ package stripe
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -31,7 +31,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Stripe and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/twitch/session.go
+++ b/providers/twitch/session.go
@@ -3,10 +3,10 @@ package twitch
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Twitch
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -4,11 +4,12 @@ package twitch
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"strconv"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -71,6 +72,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -109,7 +111,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.twitchtv.v3+json")
 	req.Header.Set("Authorization", "OAuth "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -179,7 +181,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/twitter/session.go
+++ b/providers/twitter/session.go
@@ -3,9 +3,10 @@ package twitter
 import (
 	"encoding/json"
 	"errors"
+	"strings"
+
 	"github.com/markbates/goth"
 	"github.com/mrjones/oauth"
-	"strings"
 )
 
 // Session stores data during the auth process with Twitter.

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/markbates/goth"
 	"github.com/mrjones/oauth"
 	"golang.org/x/oauth2"
-	"io/ioutil"
 )
 
 var (
@@ -52,6 +54,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	debug       bool
 	consumer    *oauth.Consumer
 }

--- a/providers/uber/session.go
+++ b/providers/uber/session.go
@@ -3,10 +3,10 @@ package uber
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Uber and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -4,10 +4,11 @@ package uber
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -21,6 +22,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -128,7 +130,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/wepay/session.go
+++ b/providers/wepay/session.go
@@ -3,10 +3,11 @@ package wepay
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 // Session stores data during the auth process with Box.
@@ -31,7 +32,7 @@ func (s Session) GetAuthURL() (string, error) {
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
 	oauth2.RegisterBrokenAuthHeaderProvider(tokenURL)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -4,12 +4,13 @@ package wepay
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -23,6 +24,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -68,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()

--- a/providers/yahoo/session.go
+++ b/providers/yahoo/session.go
@@ -3,10 +3,10 @@ package yahoo
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Box.
@@ -30,7 +30,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Yahoo and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	if err != nil {
 		return "", err
 	}

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -4,10 +4,11 @@ package yahoo
 
 import (
 	"encoding/json"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -21,6 +22,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := goth.HTTPClientWithFallBack(p.Client).Do(req)
 	if err != nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -131,7 +133,7 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
-	ts := p.config.TokenSource(oauth2.NoContext, token)
+	ts := p.config.TokenSource(goth.ContextForClient(p.Client), token)
 	newToken, err := ts.Token()
 	if err != nil {
 		return nil, err

--- a/providers/yammer/session.go
+++ b/providers/yammer/session.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/markbates/goth"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/markbates/goth"
 )
 
 // Session stores data during the auth process with Yammer.
@@ -40,7 +41,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 	//Cant use standard auth2 implementation as yammer returns access_token as json rather than string
 	//stand methods are throwing exception
-	//token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	//token, err := p.config.Exchange(goth.ContextForClient(p.Client), params.Get("code"))
 	autData, err := retrieveAuthData(p.ClientKey, p.Secret, tokenURL, v)
 	if err != nil {
 		return "", err

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -4,9 +4,11 @@ package yammer
 
 import (
 	"errors"
+	"net/http"
+	"strconv"
+
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
-	"strconv"
 )
 
 const (
@@ -20,6 +22,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
+	Client      *http.Client
 	config      *oauth2.Config
 }
 


### PR DESCRIPTION
Some providers already used a custom httpClient. This brings the `Client` field to all providers and uses a fallback method to provide the `http.DefaultClient` if no client is set. 

This also uses the custom httpClient for the oauth2 calls via the context.

The change should allow better inversion of control during unit tests by providing a custom client.

I also ran go format on some files to clean up the import statements.
