### PR TITLE
Add support for first and lastname for facebook and google plus

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -150,7 +150,7 @@ var indexTemplate = `{{range $key,$value:=.Providers}}
 {{end}}`
 
 var userTemplate = `
-<p>Name: {{.Name}}</p>
+<p>Name: {{.Name}} [{{.LastName}}, {{.FirstName}}]</p>
 <p>Email: {{.Email}}</p>
 <p>NickName: {{.NickName}}</p>
 <p>Location: {{.Location}}</p>

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -92,12 +92,14 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID      string `json:"id"`
-		Email   string `json:"email"`
-		Bio     string `json:"bio"`
-		Name    string `json:"name"`
-		Link    string `json:"link"`
-		Picture struct {
+		ID        string `json:"id"`
+		Email     string `json:"email"`
+		Bio       string `json:"bio"`
+		Name      string `json:"name"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Link      string `json:"link"`
+		Picture   struct {
 			Data struct {
 				URL string `json:"url"`
 			} `json:"data"`
@@ -113,6 +115,8 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 	}
 
 	user.Name = u.Name
+	user.FirstName = u.FirstName
+	user.LastName = u.LastName
 	user.NickName = u.Name
 	user.Email = u.Email
 	user.Description = u.Bio

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -99,11 +99,13 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID      string `json:"id"`
-		Email   string `json:"email"`
-		Name    string `json:"name"`
-		Link    string `json:"link"`
-		Picture string `json:"picture"`
+		ID        string `json:"id"`
+		Email     string `json:"email"`
+		Name      string `json:"name"`
+		FirstName string `json:"given_name"`
+		LastName  string `json:"family_name"`
+		Link      string `json:"link"`
+		Picture   string `json:"picture"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -112,6 +114,8 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 	}
 
 	user.Name = u.Name
+	user.FirstName = u.FirstName
+	user.LastName = u.LastName
 	user.NickName = u.Name
 	user.Email = u.Email
 	//user.Description = u.Bio

--- a/user.go
+++ b/user.go
@@ -16,6 +16,8 @@ type User struct {
 	Provider          string
 	Email             string
 	Name              string
+	FirstName         string
+	LastName          string
 	NickName          string
 	Description       string
 	UserID            string


### PR DESCRIPTION
We need to access the first, last name individually in order to provided better and personalized messages. This adds support for the two fields which are currently only implemented for Facebook and Google Plus. 