### PR TITLE
Configurable domains for InfluxCloud provider

### DIFF
--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -32,8 +32,17 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Config: &oauth2.Config{
+			ClientID:     clientKey,
+			ClientSecret: secret,
+			RedirectURL:  callbackURL,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  authURL,
+				TokenURL: tokenURL,
+			},
+			Scopes: scopes,
+		},
 	}
-	p.config = newConfig(p, scopes)
 	return p
 }
 
@@ -42,7 +51,7 @@ type Provider struct {
 	ClientKey   string
 	Secret      string
 	CallbackURL string
-	config      *oauth2.Config
+	Config      *oauth2.Config
 }
 
 // Name is the name used to retrieve this provider later.
@@ -55,7 +64,7 @@ func (p *Provider) Debug(debug bool) {}
 
 // BeginAuth asks Github for an authentication end-point.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
-	url := p.config.AuthCodeURL(state)
+	url := p.Config.AuthCodeURL(state)
 	session := &Session{
 		AuthURL: url,
 	}
@@ -118,25 +127,6 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 	user.Location = u.Location
 
 	return err
-}
-
-func newConfig(provider *Provider, scopes []string) *oauth2.Config {
-	c := &oauth2.Config{
-		ClientID:     provider.ClientKey,
-		ClientSecret: provider.Secret,
-		RedirectURL:  provider.CallbackURL,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  authURL,
-			TokenURL: tokenURL,
-		},
-		Scopes: []string{},
-	}
-
-	for _, scope := range scopes {
-		c.Scopes = append(c.Scopes, scope)
-	}
-
-	return c
 }
 
 //RefreshToken refresh token is not provided by influxcloud

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 
 	"github.com/markbates/goth"
@@ -19,19 +21,30 @@ import (
 const (
 	// The hard coded domain is difficult here because influx cloud has an acceptance
 	// domain that is different and we will need that for enterprise development.
-	authURL         string = "https://cloud.influxdata.com/oauth/authorize"
-	tokenURL        string = "https://cloud.influxdata.com/oauth/token"
-	endpointProfile string = "https://cloud.influxdata.com/api/v1/user"
+	defaultDomain string = "cloud.influxdata.com"
+	userAPIPath   string = "/api/v1/user"
+	domainEnvKey  string = "INFLUXCLOUD_OAUTH_DOMAIN"
+	authPath      string = "/oauth/authorize"
+	tokenPath     string = "/oauth/token"
 )
 
-// New creates a new Github provider, and sets up important connection details.
+// New creates a new influx provider, and sets up important connection details.
 // You should always call `influxcloud.New` to get a new Provider. Never try to create
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	domain := os.Getenv(domainEnvKey)
+	if domain == "" {
+		domain = defaultDomain
+	}
+	tokenURL := fmt.Sprintf("https://%s%s", domain, tokenPath)
+	authURL := fmt.Sprintf("https://%s%s", domain, authPath)
+	userAPIEndpoint := fmt.Sprintf("https://%s%s", domain, userAPIPath)
+
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
+		ClientKey:       clientKey,
+		Secret:          secret,
+		CallbackURL:     callbackURL,
+		UserAPIEndpoint: userAPIEndpoint,
 		Config: &oauth2.Config{
 			ClientID:     clientKey,
 			ClientSecret: secret,
@@ -46,12 +59,13 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	return p
 }
 
-// Provider is the implementation of `goth.Provider` for accessing Github.
+// Provider is the implementation of `goth.Provider` for accessing Influx.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	Config      *oauth2.Config
+	ClientKey       string
+	Secret          string
+	CallbackURL     string
+	UserAPIEndpoint string
+	Config          *oauth2.Config
 }
 
 // Name is the name used to retrieve this provider later.
@@ -62,7 +76,7 @@ func (p *Provider) Name() string {
 // Debug is a no-op for the influxcloud package.
 func (p *Provider) Debug(debug bool) {}
 
-// BeginAuth asks Github for an authentication end-point.
+// BeginAuth asks Influx for an authentication end-point.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	url := p.Config.AuthCodeURL(state)
 	session := &Session{
@@ -71,7 +85,7 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	return session, nil
 }
 
-// FetchUser will go to Github and access basic information about the user.
+// FetchUser will go to Influx and access basic information about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
@@ -79,7 +93,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := http.Get(p.UserAPIEndpoint + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()

--- a/providers/influxcloud/session.go
+++ b/providers/influxcloud/session.go
@@ -26,7 +26,7 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with Github and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	token, err := p.Config.Exchange(oauth2.NoContext, params.Get("code"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Configurable domains for InfluxCloud provider via the environment variable `INFLUXCLOUD_OAUTH_DOMAIN`, the developer can specify which domain to use for the InfluxCloud OAuth Provider.