### PR TITLE
Add Intercom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ go get github.com/markbates/goth
 * Heroku
 * InfluxCloud
 * Instagram
+* Intercom
 * Lastfm
 * Linkedin
 * OneDrive

--- a/examples/main.go
+++ b/examples/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/markbates/goth/providers/gplus"
 	"github.com/markbates/goth/providers/heroku"
 	"github.com/markbates/goth/providers/instagram"
+	"github.com/markbates/goth/providers/intercom"
 	"github.com/markbates/goth/providers/lastfm"
 	"github.com/markbates/goth/providers/linkedin"
 	"github.com/markbates/goth/providers/onedrive"
@@ -65,6 +66,7 @@ func main() {
 		digitalocean.New(os.Getenv("DIGITALOCEAN_KEY"), os.Getenv("DIGITALOCEAN_SECRET"), "http://localhost:3000/auth/digitalocean/callback", "read"),
 		bitbucket.New(os.Getenv("BITBUCKET_KEY"), os.Getenv("BITBUCKET_SECRET"), "http://localhost:3000/auth/bitbucket/callback"),
 		instagram.New(os.Getenv("INSTAGRAM_KEY"), os.Getenv("INSTAGRAM_SECRET"), "http://localhost:3000/auth/instagram/callback"),
+		intercom.New(os.Getenv("INTERCOM_KEY"), os.Getenv("INTERCOM_SECRET"), "http://localhost:3000/auth/intercom/callback"),
 		box.New(os.Getenv("BOX_KEY"), os.Getenv("BOX_SECRET"), "http://localhost:3000/auth/box/callback"),
 		salesforce.New(os.Getenv("SALESFORCE_KEY"), os.Getenv("SALESFORCE_SECRET"), "http://localhost:3000/auth/salesforce/callback"),
 		amazon.New(os.Getenv("AMAZON_KEY"), os.Getenv("AMAZON_SECRET"), "http://localhost:3000/auth/amazon/callback"),
@@ -111,6 +113,7 @@ func main() {
 	m["gplus"] = "Google Plus"
 	m["heroku"] = "Heroku"
 	m["instagram"] = "Instagram"
+	m["intercom"] = "Intercom"
 	m["lastfm"] = "Last FM"
 	m["linkedin"] = "Linkedin"
 	m["onedrive"] = "Onedrive"

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -1,0 +1,158 @@
+// Package intercom implements the OAuth protocol for authenticating users through Intercom.
+package intercom
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	authURL  string = "https://app.intercom.io/oauth"
+	tokenURL string = "https://api.intercom.io/auth/eagle/token?client_secret=%s"
+	userURL  string = "https://api.intercom.io/me"
+)
+
+// New creates the new Intercom provider
+func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	p := &Provider{
+		ClientKey:   clientKey,
+		Secret:      secret,
+		CallbackURL: callbackURL,
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Provider is the implementation of `goth.Provider` for accessing Intercom
+type Provider struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	config      *oauth2.Config
+}
+
+// Name is the name used to retrieve this provider later.
+func (p *Provider) Name() string {
+	return "intercom"
+}
+
+// Debug is a no-op for the intercom package
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks Intercom for an authentication end-point
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	url := p.config.AuthCodeURL(state)
+	session := &Session{
+		AuthURL: url,
+	}
+	return session, nil
+}
+
+// FetchUser will fetch basic information about Intercom admin
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	sess := session.(*Session)
+	user := goth.User{
+		AccessToken: sess.AccessToken,
+		Provider:    p.Name(),
+		ExpiresAt:   sess.ExpiresAt,
+	}
+
+	request, err := http.NewRequest("GET", userURL, nil)
+	if err != nil {
+		return user, err
+	}
+	request.Header.Add("Accept", "application/json")
+	request.SetBasicAuth(sess.AccessToken, "")
+
+	response, err := http.DefaultClient.Do(request)
+
+	if err != nil {
+		if response != nil {
+			response.Body.Close()
+		}
+		return user, err
+	}
+	defer response.Body.Close()
+
+	bits, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return user, err
+	}
+
+	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&user.RawData)
+	if err != nil {
+		return user, err
+	}
+
+	err = userFromReader(bytes.NewReader(bits), &user)
+	return user, err
+}
+
+func userFromReader(reader io.Reader, user *goth.User) error {
+	u := struct {
+		ID     string `json:"id"`
+		Email  string `json:"email"`
+		Name   string `json:"name"`
+		Link   string `json:"link"`
+		Avatar struct {
+			URL string `json:"image_url"`
+		} `json:"avatar"`
+	}{}
+
+	err := json.NewDecoder(reader).Decode(&u)
+	if err != nil {
+		return err
+	}
+
+	user.Name = u.Name
+	user.FirstName, user.LastName = splitName(u.Name)
+	user.Email = u.Email
+	user.AvatarURL = u.Avatar.URL
+	user.UserID = u.ID
+
+	return err
+}
+
+func splitName(name string) (string, string) {
+	nameSplit := strings.SplitN(name, " ", 2)
+	firstName := nameSplit[0]
+
+	var lastName string
+	if len(nameSplit) == 2 {
+		lastName = nameSplit[1]
+	}
+
+	return firstName, lastName
+}
+
+func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     provider.ClientKey,
+		ClientSecret: provider.Secret,
+		RedirectURL:  provider.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: fmt.Sprintf(tokenURL, provider.Secret),
+		},
+	}
+
+	return c
+}
+
+// RefreshToken refresh token is not provided by Intercom
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("Refresh token is not provided by Intercom")
+}
+
+// RefreshTokenAvailable refresh token is not provided by Intercom
+func (p *Provider) RefreshTokenAvailable() bool {
+	return false
+}

--- a/providers/intercom/intercom_test.go
+++ b/providers/intercom/intercom_test.go
@@ -1,0 +1,54 @@
+package intercom_test
+
+import (
+	"fmt"
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/intercom"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := intercomProvider()
+	a.Equal(provider.ClientKey, os.Getenv("INTERCOM_KEY"))
+	a.Equal(provider.Secret, os.Getenv("INTERCOM_SECRET"))
+	a.Equal(provider.CallbackURL, "/foo")
+}
+
+func Test_Implements_Provider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	a.Implements((*goth.Provider)(nil), intercomProvider())
+}
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	provider := intercomProvider()
+	session, err := provider.BeginAuth("test_state")
+	s := session.(*intercom.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "https://app.intercom.io/oauth")
+	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("INTERCOM_KEY")))
+	a.Contains(s.AuthURL, "state=test_state")
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := intercomProvider()
+
+	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.intercom.io/oauth","AccessToken":"1234567890"}`)
+	a.NoError(err)
+	session := s.(*intercom.Session)
+	a.Equal(session.AuthURL, "https://app.intercom.io/oauth")
+	a.Equal(session.AccessToken, "1234567890")
+}
+
+func intercomProvider() *intercom.Provider {
+	return intercom.New(os.Getenv("INTERCOM_KEY"), os.Getenv("INTERCOM_SECRET"), "/foo", "basic")
+}

--- a/providers/intercom/session.go
+++ b/providers/intercom/session.go
@@ -1,0 +1,59 @@
+package intercom
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+	"strings"
+	"time"
+)
+
+// Session stores data during the auth process with intercom.
+type Session struct {
+	AuthURL     string
+	AccessToken string
+	ExpiresAt   time.Time
+}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the intercom provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New("an AuthURL has not be set")
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with intercom and return the access token to be stored for future use.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	if err != nil {
+		return "", err
+	}
+
+	if !token.Valid() {
+		return "", errors.New("Invalid token received from provider")
+	}
+
+	s.AccessToken = token.AccessToken
+	s.ExpiresAt = token.Expiry
+	return token.AccessToken, err
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}
+
+// UnmarshalSession will unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	sess := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(sess)
+	return sess, err
+}

--- a/providers/intercom/session_test.go
+++ b/providers/intercom/session_test.go
@@ -1,0 +1,47 @@
+package intercom_test
+
+import (
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/intercom"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Implements_Session(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &intercom.Session{}
+
+	a.Implements((*goth.Session)(nil), s)
+}
+
+func Test_GetAuthURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &intercom.Session{}
+
+	_, err := s.GetAuthURL()
+	a.Error(err)
+
+	s.AuthURL = "/foo"
+
+	url, _ := s.GetAuthURL()
+	a.Equal(url, "/foo")
+}
+
+func Test_ToJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &intercom.Session{}
+
+	data := s.Marshal()
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
+}
+
+func Test_String(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &intercom.Session{}
+
+	a.Equal(s.String(), s.Marshal())
+}


### PR DESCRIPTION
This adds support for [Intercom](https://intercom.io), with tests and example.

![goth-intercom](https://cloud.githubusercontent.com/assets/62379/18250567/0cebc1e6-737c-11e6-88d0-fb6c973d6648.gif)

