### PR TITLE
Update LinkedIn OAuth Endpoints to latest correct version

### DIFF
--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -14,8 +14,8 @@ import (
 //more details about linkedin fields: https://developer.linkedin.com/documents/profile-fields
 
 const (
-	authURL  string = "https://www.linkedin.com/uas/oauth2/authorization"
-	tokenURL string = "https://www.linkedin.com/uas/oauth2/accessToken"
+	authURL  string = "https://www.linkedin.com/oauth/v2/authorization"
+	tokenURL string = "https://www.linkedin.com/oauth/v2/accessToken"
 
 	//userEndpoint requires scopes "r_basicprofile", "r_emailaddress"
 	userEndpoint string = "//api.linkedin.com/v1/people/~:(id,first-name,last-name,headline,location:(name),picture-url,email-address)"

--- a/providers/linkedin/linkedin_test.go
+++ b/providers/linkedin/linkedin_test.go
@@ -35,7 +35,7 @@ func Test_BeginAuth(t *testing.T) {
 	session, err := provider.BeginAuth("test_state")
 	s := session.(*linkedin.Session)
 	a.NoError(err)
-	a.Contains(s.AuthURL, "linkedin.com/uas/oauth2/authorization")
+	a.Contains(s.AuthURL, "linkedin.com/oauth/v2/authorization")
 	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("LINKEDIN_KEY")))
 	a.Contains(s.AuthURL, "state=test_state")
 	a.Contains(s.AuthURL, "scope=r_basicprofile+r_emailaddress&state")


### PR DESCRIPTION
Current implementation is using outdated LinkedIn endpoints (as per https://developer.linkedin.com/docs/oauth2) which return URL Fragments on authorization. Updated to latest endpoints.