### PR TITLE
Revert "Fixed http exotic connection leak"

### DIFF
--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -66,10 +66,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -69,9 +69,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()
@@ -90,9 +87,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err = http.Get(endpointEmail + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -70,9 +70,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "&access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -81,9 +81,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -76,9 +76,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -15,7 +15,7 @@ import (
 var (
 	authURL         = "https://api.instagram.com/oauth/authorize/"
 	tokenURL        = "https://api.instagram.com/oauth/access_token"
-	endpointProfile = "https://api.instagram.com/v1/users/self/"
+	endPointProfile = "https://api.instagram.com/v1/users/self/"
 )
 
 // New creates a new Instagram provider, and sets up important connection details.
@@ -65,11 +65,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
-	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := http.Get(endPointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -67,9 +67,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := http.Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
-		if response != nil {
-			response.Body.Close()
-		}
 		return user, err
 	}
 	defer response.Body.Close()


### PR DESCRIPTION
Reverts markbates/goth#66

Finally this exotic bug has been clarified by the Go project right before April 1st 2016 (not a joke):
https://github.com/golang/go/commit/aecfcd827edb4a7ab6248668f7329a330e1f0e4a

So the previous patch is finally useless, and added unneeded complexity to goth code.