### PR TITLE
Revert "Fixed http exotic connection leak"

### DIFF
--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -68,9 +68,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -77,9 +77,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -73,9 +73,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	req.Header.Set("Authorization", "Bearer "+s.Token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -143,9 +143,6 @@ func (p *Provider) request(sign bool, params map[string]string, result interface
 
 	res, err := client.Do(req)
 	if err != nil {
-		if res != nil {
-			res.Body.Close()
-		}
 		return err
 	}
 

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -84,9 +84,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	req.Header.Add("x-li-format", "json") //request json response
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -72,9 +72,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -101,9 +101,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -111,9 +111,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	req.Header.Set("Authorization", "OAuth "+s.AccessToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if resp != nil {
-			resp.Body.Close()
-		}
 		return user, err
 	}
 	defer resp.Body.Close()

--- a/providers/yammer/session.go
+++ b/providers/yammer/session.go
@@ -74,9 +74,6 @@ func retrieveAuthData(ClientID, ClientSecret, TokenURL string, v url.Values) (ma
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if r != nil {
-			r.Body.Close()
-		}
 		return nil, err
 	}
 	defer r.Body.Close()


### PR DESCRIPTION
Reverts markbates/goth#67

Finally this exotic bug has been clarified by the Go project right before April 1st 2016 (not a joke):
https://github.com/golang/go/commit/aecfcd827edb4a7ab6248668f7329a330e1f0e4a

So the previous patch is finally useless, and added unneeded complexity to goth code.