### PR TITLE
Make "no Auth URL" error message uniform in all providers

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -15,6 +15,8 @@ type Provider interface {
 	RefreshTokenAvailable() bool                             //Refresh token is provided by auth provider or not
 }
 
+const NoAuthUrlErrorMessage = "an AuthURL has not been set"
+
 // Providers is list of known/available providers.
 type Providers map[string]Provider
 

--- a/providers/amazon/session.go
+++ b/providers/amazon/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/auth0/session.go
+++ b/providers/auth0/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/bitbucket/session.go
+++ b/providers/bitbucket/session.go
@@ -20,7 +20,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Bitbucket provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/box/session.go
+++ b/providers/box/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/deezer/session.go
+++ b/providers/deezer/session.go
@@ -19,7 +19,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Deezer provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/digitalocean/session.go
+++ b/providers/digitalocean/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the DigitalOcean provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/discord/session.go
+++ b/providers/discord/session.go
@@ -21,7 +21,7 @@ type Session struct {
 // the Discord provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("Discord: An AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/facebook/session.go
+++ b/providers/facebook/session.go
@@ -19,7 +19,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Facebook provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/fitbit/session.go
+++ b/providers/fitbit/session.go
@@ -21,7 +21,7 @@ type Session struct {
 // Fitbit provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("fitbit: AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/github/session.go
+++ b/providers/github/session.go
@@ -17,7 +17,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Github provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/gitlab/session.go
+++ b/providers/gitlab/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/gplus/session.go
+++ b/providers/gplus/session.go
@@ -20,7 +20,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Google+ provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/heroku/session.go
+++ b/providers/heroku/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/influxcloud/session.go
+++ b/providers/influxcloud/session.go
@@ -18,7 +18,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Github provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/instagram/session.go
+++ b/providers/instagram/session.go
@@ -17,7 +17,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Instagram provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/intercom/session.go
+++ b/providers/intercom/session.go
@@ -19,7 +19,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the intercom provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/lastfm/session.go
+++ b/providers/lastfm/session.go
@@ -17,7 +17,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the LastFM provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/linkedin/session.go
+++ b/providers/linkedin/session.go
@@ -18,7 +18,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Linkedin provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/onedrive/session.go
+++ b/providers/onedrive/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/paypal/session.go
+++ b/providers/paypal/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/salesforce/session.go
+++ b/providers/salesforce/session.go
@@ -30,7 +30,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Salesforce provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/slack/session.go
+++ b/providers/slack/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/spotify/session.go
+++ b/providers/spotify/session.go
@@ -20,7 +20,7 @@ type Session struct {
 // Spotify provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("spotify: AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/steam/session.go
+++ b/providers/steam/session.go
@@ -23,7 +23,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Steam provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("An AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/stripe/session.go
+++ b/providers/stripe/session.go
@@ -23,7 +23,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/twitch/session.go
+++ b/providers/twitch/session.go
@@ -21,7 +21,7 @@ type Session struct {
 // the Twitch provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("Twitch: An AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/twitter/session.go
+++ b/providers/twitter/session.go
@@ -18,7 +18,7 @@ type Session struct {
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Twitter provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/uber/session.go
+++ b/providers/uber/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/wepay/session.go
+++ b/providers/wepay/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/yahoo/session.go
+++ b/providers/yahoo/session.go
@@ -22,7 +22,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Box provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("AuthURL has not been set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }

--- a/providers/yammer/session.go
+++ b/providers/yammer/session.go
@@ -24,7 +24,7 @@ var _ goth.Session = &Session{}
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Yammer provider.
 func (s Session) GetAuthURL() (string, error) {
 	if s.AuthURL == "" {
-		return "", errors.New("an AuthURL has not be set")
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
 	}
 	return s.AuthURL, nil
 }


### PR DESCRIPTION
I noticed some of the error messages had a typo, and they were
different for some providers. This is my first attempt to make them
all the same.

Some error messages are listing the providers as well, I am happy to
do that in the future if you think this is a good direction for the
code.