### PR TITLE
Support multiple instances of one provider type

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -11,7 +11,7 @@ import (
 // Provider needs to be implemented for each 3rd party authentication provider
 // e.g. Facebook, Twitter, etc...
 type Provider interface {
-	Name() string
+	GetName() string
 	BeginAuth(state string) (Session, error)
 	UnmarshalSession(string) (Session, error)
 	FetchUser(Session) (User, error)
@@ -32,7 +32,7 @@ var providers = Providers{}
 // than once, the last will be used.
 func UseProviders(viders ...Provider) {
 	for _, provider := range viders {
-		providers[provider.Name()] = provider
+		providers[provider.GetName()] = provider
 	}
 }
 

--- a/provider.go
+++ b/provider.go
@@ -11,7 +11,8 @@ import (
 // Provider needs to be implemented for each 3rd party authentication provider
 // e.g. Facebook, Twitter, etc...
 type Provider interface {
-	GetName() string
+	Name() string
+	SetName(name string)
 	BeginAuth(state string) (Session, error)
 	UnmarshalSession(string) (Session, error)
 	FetchUser(Session) (User, error)
@@ -32,7 +33,7 @@ var providers = Providers{}
 // than once, the last will be used.
 func UseProviders(viders ...Provider) {
 	for _, provider := range viders {
-		providers[provider.GetName()] = provider
+		providers[provider.Name()] = provider
 	}
 }
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -14,7 +14,7 @@ func Test_UseProviders(t *testing.T) {
 	provider := &faux.Provider{}
 	goth.UseProviders(provider)
 	a.Equal(len(goth.GetProviders()), 1)
-	a.Equal(goth.GetProviders()[provider.GetName()], provider)
+	a.Equal(goth.GetProviders()[provider.Name()], provider)
 	goth.ClearProviders()
 }
 
@@ -24,7 +24,7 @@ func Test_GetProvider(t *testing.T) {
 	provider := &faux.Provider{}
 	goth.UseProviders(provider)
 
-	p, err := goth.GetProvider(provider.GetName())
+	p, err := goth.GetProvider(provider.Name())
 	a.NoError(err)
 	a.Equal(p, provider)
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -14,7 +14,7 @@ func Test_UseProviders(t *testing.T) {
 	provider := &faux.Provider{}
 	goth.UseProviders(provider)
 	a.Equal(len(goth.GetProviders()), 1)
-	a.Equal(goth.GetProviders()[provider.Name()], provider)
+	a.Equal(goth.GetProviders()[provider.GetName()], provider)
 	goth.ClearProviders()
 }
 
@@ -24,7 +24,7 @@ func Test_GetProvider(t *testing.T) {
 	provider := &faux.Provider{}
 	goth.UseProviders(provider)
 
-	p, err := goth.GetProvider(provider.Name())
+	p, err := goth.GetProvider(provider.GetName())
 	a.NoError(err)
 	a.Equal(p, provider)
 

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -27,6 +27,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Amazon provider and sets up important connection details.
@@ -37,6 +38,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "amazon",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -47,8 +49,8 @@ func (p *Provider) Client() *http.Client {
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "amazon"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 // Debug is a no-op for the amazon package.
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -22,12 +22,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Amazon.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Amazon provider and sets up important connection details.
@@ -35,10 +35,10 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "amazon",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "amazon",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -49,8 +49,13 @@ func (p *Provider) Client() *http.Client {
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 // Debug is a no-op for the amazon package.
@@ -68,7 +73,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -27,6 +27,7 @@ type Provider struct {
 	Domain      string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 type auth0UserResp struct {
@@ -46,14 +47,15 @@ func New(clientKey, secret, callbackURL string, auth0Domain string, scopes ...st
 		Secret:      secret,
 		CallbackURL: callbackURL,
 		Domain:      auth0Domain,
+		Name:        "auth0",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "auth0"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -78,7 +80,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -21,13 +21,13 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Auth0.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	Domain      string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	Domain       string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 type auth0UserResp struct {
@@ -43,19 +43,24 @@ type auth0UserResp struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, auth0Domain string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Domain:      auth0Domain,
-		Name:        "auth0",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		Domain:              auth0Domain,
+		providerName:        "auth0",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -80,7 +85,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -28,6 +28,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "bitbucket",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -40,11 +41,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "bitbucket"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -68,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}
@@ -108,7 +110,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID    string `json:"uuid"`
+		ID string `json:"uuid"`
 		Links struct {
 			Avatar struct {
 				URL string `json:"href"`

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -25,10 +25,10 @@ const (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "bitbucket",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "bitbucket",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -36,17 +36,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Bitbucket.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -70,7 +75,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -24,6 +24,7 @@ type Provider struct {
 	CallbackURL string
 	config      *oauth2.Config
 	HTTPClient  *http.Client
+	Name        string
 }
 
 // New creates a new Box provider and sets up important connection details.
@@ -34,14 +35,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "box",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "box"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -63,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -19,12 +19,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Box.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	config      *oauth2.Config
-	HTTPClient  *http.Client
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	config       *oauth2.Config
+	HTTPClient   *http.Client
+	providerName string
 }
 
 // New creates a new Box provider and sets up important connection details.
@@ -32,18 +32,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "box",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "box",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -17,15 +17,15 @@ import (
 
 // Provider is the implementation of `goth.Provider` for accessing Cloud Foundry.
 type Provider struct {
-	AuthURL     string
-	TokenURL    string
-	UserInfoURL string
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	AuthURL      string
+	TokenURL     string
+	UserInfoURL  string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Cloud Foundry provider and sets up important connection details.
@@ -34,21 +34,26 @@ type Provider struct {
 func New(uaaURL, clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	uaaURL = strings.TrimSuffix(uaaURL, "/")
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		AuthURL:     uaaURL + "/oauth/authorize",
-		TokenURL:    uaaURL + "/oauth/token",
-		UserInfoURL: uaaURL + "/userinfo",
-		Name:        "cloudfoundry",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		AuthURL:             uaaURL + "/oauth/authorize",
+		TokenURL:            uaaURL + "/oauth/token",
+		UserInfoURL:         uaaURL + "/userinfo",
+		providerName:        "cloudfoundry",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -70,7 +75,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -25,6 +25,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Cloud Foundry provider and sets up important connection details.
@@ -39,14 +40,15 @@ func New(uaaURL, clientKey, secret, callbackURL string, scopes ...string) *Provi
 		AuthURL:     uaaURL + "/oauth/authorize",
 		TokenURL:    uaaURL + "/oauth/token",
 		UserInfoURL: uaaURL + "/userinfo",
+		Name:        "cloudfoundry",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "cloudfoundry"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -68,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -27,6 +27,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Dailymotion provider and sets up important connection details.
@@ -37,14 +38,15 @@ func New(clientKey string, secret string, callbackURL string, scopes ...string) 
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "dailymotion",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "dailymotion"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -22,12 +22,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Dailymotion.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Dailymotion provider and sets up important connection details.
@@ -35,18 +35,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey string, secret string, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "dailymotion",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "dailymotion",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -68,7 +73,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -28,6 +28,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Deezer provider and sets up important connection details.
@@ -38,14 +39,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "deezer",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "deezer"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -67,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 		ExpiresAt:   sess.ExpiresAt,
 	}
 

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -23,12 +23,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Deezer.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Deezer provider and sets up important connection details.
@@ -36,18 +36,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "deezer",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "deezer",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -69,7 +74,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 		ExpiresAt:   sess.ExpiresAt,
 	}
 

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -24,10 +24,10 @@ const (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "digialocean",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "digialocean",
 	}
 
 	p.config = newConfig(p, scopes)
@@ -36,19 +36,24 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing DigitalOcean.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 var _ goth.Provider = &Provider{}
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -72,7 +77,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -27,6 +27,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "digialocean",
 	}
 
 	p.config = newConfig(p, scopes)
@@ -40,13 +41,14 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 var _ goth.Provider = &Provider{}
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "digitalocean"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -70,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -47,6 +47,7 @@ func New(clientKey string, secret string, callbackURL string, scopes ...string) 
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "discord",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -59,11 +60,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) Name() string {
-	return "discord"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -91,7 +93,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -44,10 +44,10 @@ const (
 // one manually.
 func New(clientKey string, secret string, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "discord",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "discord",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -55,17 +55,22 @@ func New(clientKey string, secret string, callbackURL string, scopes ...string) 
 
 // Provider is the implementation of `goth.Provider` for accessing Discord
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -93,7 +98,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -20,12 +20,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Dropbox.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Session stores data during the auth process with Dropbox.
@@ -39,18 +39,23 @@ type Session struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "dropbox",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "dropbox",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -72,7 +77,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken: s.Token,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 	}
 	req, err := http.NewRequest("GET", accountURL, nil)
 	if err != nil {

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -25,6 +25,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Session stores data during the auth process with Dropbox.
@@ -41,14 +42,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "dropbox",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "dropbox"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -70,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken: s.Token,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 	}
 	req, err := http.NewRequest("GET", accountURL, nil)
 	if err != nil {
@@ -143,7 +145,7 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 
 func userFromReader(r io.Reader, user *goth.User) error {
 	u := struct {
-		Name        string `json:"display_name"`
+		Name string `json:"display_name"`
 		NameDetails struct {
 			NickName string `json:"familiar_name"`
 		} `json:"name_details"`

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -26,10 +26,10 @@ const (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "facebook",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "facebook",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -37,17 +37,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Facebook.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -71,7 +76,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 		ExpiresAt:   sess.ExpiresAt,
 	}
 

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -29,6 +29,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "facebook",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -41,11 +42,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "facebook"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -69,7 +71,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 		ExpiresAt:   sess.ExpiresAt,
 	}
 
@@ -102,7 +104,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		FirstName string `json:"first_name"`
 		LastName  string `json:"last_name"`
 		Link      string `json:"link"`
-		Picture   struct {
+		Picture struct {
 			Data struct {
 				URL string `json:"url"`
 			} `json:"data"`

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -13,8 +13,8 @@ import (
 
 // Provider is used only for testing.
 type Provider struct {
-	HTTPClient *http.Client
-	Name string
+	HTTPClient   *http.Client
+	providerName string
 }
 
 // Session is used only for testing.
@@ -25,8 +25,13 @@ type Session struct {
 }
 
 // Name is used only for testing.
-func (p *Provider) GetName() string {
+func (p *Provider) Name() string {
 	return "faux"
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 // BeginAuth is used only for testing.
@@ -38,9 +43,9 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	return goth.User{
-		UserID: sess.ID,
-		Name:   sess.Name,
-		Email:  sess.Email,
+		UserID:          sess.ID,
+		Name:            sess.Name,
+		Email:           sess.Email,
 	}, nil
 }
 

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -14,6 +14,7 @@ import (
 // Provider is used only for testing.
 type Provider struct {
 	HTTPClient *http.Client
+	Name string
 }
 
 // Session is used only for testing.
@@ -24,7 +25,7 @@ type Session struct {
 }
 
 // Name is used only for testing.
-func (p *Provider) Name() string {
+func (p *Provider) GetName() string {
 	return "faux"
 }
 

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -46,6 +46,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "fitbit",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -58,11 +59,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "fitbit"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -86,7 +88,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 		UserID:       s.UserID,

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -43,10 +43,10 @@ const (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "fitbit",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "fitbit",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -54,17 +54,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Fitbit.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -88,7 +93,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 		UserID:       s.UserID,

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -41,6 +41,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "github",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -53,11 +54,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "github"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -81,7 +83,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 	}
 
 	response, err := p.Client().Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -38,10 +38,10 @@ var (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "github",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "github",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -49,17 +49,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Github.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -83,7 +88,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 	}
 
 	response, err := p.Client().Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -35,6 +35,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Gitlab provider and sets up important connection details.
@@ -45,14 +46,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "gitlab",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "gitlab"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -74,7 +76,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -30,12 +30,12 @@ var (
 
 // Provider is the implementation of `goth.Provider` for accessing Gitlab.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Gitlab provider and sets up important connection details.
@@ -43,18 +43,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "gitlab",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "gitlab",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -76,7 +81,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -29,6 +29,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "gplus",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -42,11 +43,12 @@ type Provider struct {
 	HTTPClient  *http.Client
 	config      *oauth2.Config
 	prompt      oauth2.AuthCodeOption
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "gplus"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -74,7 +76,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -26,10 +26,10 @@ const (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "gplus",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "gplus",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -37,18 +37,23 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Google+.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	prompt      oauth2.AuthCodeOption
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	prompt       oauth2.AuthCodeOption
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -76,7 +81,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -19,12 +19,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Heroku.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Heroku provider and sets up important connection details.
@@ -32,18 +32,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name: "heroku",
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "heroku",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -24,6 +24,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name string
 }
 
 // New creates a new Heroku provider and sets up important connection details.
@@ -34,14 +35,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name: "heroku",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "heroku"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -63,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -55,7 +55,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 			},
 			Scopes: scopes,
 		},
-		Name: "influxcloud",
+		providerName: "influxcloud",
 	}
 	return p
 }
@@ -68,12 +68,17 @@ type Provider struct {
 	UserAPIEndpoint string
 	HTTPClient      *http.Client
 	Config          *oauth2.Config
-	Name            string
+	providerName    string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -97,7 +102,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 	}
 
 	response, err := p.Client().Get(p.UserAPIEndpoint + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -55,6 +55,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 			},
 			Scopes: scopes,
 		},
+		Name: "influxcloud",
 	}
 	return p
 }
@@ -67,11 +68,12 @@ type Provider struct {
 	UserAPIEndpoint string
 	HTTPClient      *http.Client
 	Config          *oauth2.Config
+	Name            string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "influxcloud"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -95,7 +97,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 	}
 
 	response, err := p.Client().Get(p.UserAPIEndpoint + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -29,6 +29,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "instagram",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -42,11 +43,12 @@ type Provider struct {
 	UserAgent   string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrive this provider later.
-func (p *Provider) Name() string {
-	return "instagram"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -70,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 	}
 
 	response, err := p.Client().Get(endPointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
@@ -101,7 +103,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 			ProfilePicture string `json:"profile_picture"`
 			Bio            string `json:"bio"`
 			Website        string `json:"website"`
-			Counts         struct {
+			Counts struct {
 				Media      int `json:"media"`
 				Follows    int `json:"follows"`
 				FollowedBy int `json:"followed_by"`

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -26,10 +26,10 @@ var (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "instagram",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "instagram",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -37,18 +37,23 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Instagram
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	UserAgent   string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	UserAgent    string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrive this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -72,7 +77,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 	}
 
 	response, err := p.Client().Get(endPointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -24,10 +24,10 @@ const (
 // New creates the new Intercom provider
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "intercom",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "intercom",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -35,17 +35,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Intercom
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -69,7 +74,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 		ExpiresAt:   sess.ExpiresAt,
 	}
 

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -27,6 +27,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "intercom",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -39,11 +40,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "intercom"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -67,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 		ExpiresAt:   sess.ExpiresAt,
 	}
 
@@ -104,10 +106,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		ID     string `json:"id"`
-		Email  string `json:"email"`
-		Name   string `json:"name"`
-		Link   string `json:"link"`
+		ID    string `json:"id"`
+		Email string `json:"email"`
+		Name  string `json:"name"`
+		Link  string `json:"link"`
 		Avatar struct {
 			URL string `json:"image_url"`
 		} `json:"avatar"`

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -30,6 +30,7 @@ func New(clientKey string, secret string, callbackURL string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "lastfm",
 	}
 	return p
 }
@@ -41,11 +42,12 @@ type Provider struct {
 	CallbackURL string
 	UserAgent   string
 	HTTPClient  *http.Client
+	Name        string
 }
 
 // Name is the name used to retrive this provider later.
-func (p *Provider) Name() string {
-	return "lastfm"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -73,7 +75,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 	}
 
 	u := struct {

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -27,27 +27,32 @@ var (
 // one manullay.
 func New(clientKey string, secret string, callbackURL string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "lastfm",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "lastfm",
 	}
 	return p
 }
 
 // Provider is the implementation of `goth.Provider` for accessing LastFM
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	UserAgent   string
-	HTTPClient  *http.Client
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	UserAgent    string
+	HTTPClient   *http.Client
+	providerName string
 }
 
 // Name is the name used to retrive this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -75,7 +80,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 	}
 
 	u := struct {

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -27,10 +27,10 @@ const (
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "linkedin",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "linkedin",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -38,17 +38,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Linkedin.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -72,7 +77,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken: s.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 		ExpiresAt:   s.ExpiresAt,
 	}
 

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -30,6 +30,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "linkedin",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -42,11 +43,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "linkedin"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -70,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken: s.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 		ExpiresAt:   s.ExpiresAt,
 	}
 
@@ -107,7 +109,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		LastName   string `json:"lastName"`
 		Headline   string `json:"headline"`
 		PictureURL string `json:"pictureUrl"`
-		Location   struct {
+		Location struct {
 			Name string `json:"name"`
 		} `json:"location"`
 	}{}

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -27,6 +27,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Onedrive provider and sets up important connection details.
@@ -37,14 +38,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name: "onedrive",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "onedrive"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -66,7 +68,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -22,12 +22,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Onedrive.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Onedrive provider and sets up important connection details.
@@ -35,18 +35,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name: "onedrive",
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "onedrive",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -68,7 +73,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -55,7 +55,7 @@ type Provider struct {
 	HTTPClient   *http.Client
 	config       *oauth2.Config
 	openIDConfig *OpenIDConfig
-	Name         string
+	providerName string
 
 	UserIdClaims    []string
 	NameClaims      []string
@@ -98,7 +98,7 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 		LastNameClaims: []string{FamilyNameClaim},
 		LocationClaims: []string{AddressClaim},
 
-		Name: "openid-connect",
+		providerName: "openid-connect",
 	}
 
 	openIDConfig, err := getOpenIDConfig(p, openIDAutoDiscoveryURL)
@@ -112,8 +112,13 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -160,7 +165,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    expiresAt,
 		RawData:      claims,

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -55,6 +55,7 @@ type Provider struct {
 	HTTPClient   *http.Client
 	config       *oauth2.Config
 	openIDConfig *OpenIDConfig
+	Name         string
 
 	UserIdClaims    []string
 	NameClaims      []string
@@ -96,6 +97,8 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 		FirstNameClaims:[]string{GivenNameClaim},
 		LastNameClaims: []string{FamilyNameClaim},
 		LocationClaims: []string{AddressClaim},
+
+		Name: "openid-connect",
 	}
 
 	openIDConfig, err := getOpenIDConfig(p, openIDAutoDiscoveryURL)
@@ -109,8 +112,8 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "openid-connect"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -157,7 +160,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    expiresAt,
 		RawData:      claims,

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -32,12 +32,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Paypal.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Paypal provider and sets up important connection details.
@@ -45,18 +45,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "paypal",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "paypal",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -78,7 +83,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -37,6 +37,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Paypal provider and sets up important connection details.
@@ -47,14 +48,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "paypal",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "paypal"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -76,7 +78,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}
@@ -153,7 +155,7 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 
 func userFromReader(r io.Reader, user *goth.User) error {
 	u := struct {
-		Name    string `json:"name"`
+		Name string `json:"name"`
 		Address struct {
 			Locality string `json:"locality"`
 		} `json:"address"`

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -16,7 +16,7 @@ const (
 	authURL  string = "https://login.salesforce.com/services/oauth2/authorize"
 	tokenURL string = "https://login.salesforce.com/services/oauth2/token"
 
-//endpointProfile    string = "https://api.salesforce.com/2.0/users/me"
+	//endpointProfile    string = "https://api.salesforce.com/2.0/users/me"
 )
 
 // Provider is the implementation of `goth.Provider` for accessing Salesforce.
@@ -26,6 +26,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Salesforce provider and sets up important connection details.
@@ -36,14 +37,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "salesforce",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "salesforce"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +67,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 	}
 	url, err := url.Parse(s.ID)

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -21,12 +21,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Salesforce.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Salesforce provider and sets up important connection details.
@@ -34,18 +34,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "salesforce",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "salesforce",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -67,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 	}
 	url, err := url.Parse(s.ID)

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -28,6 +28,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Slack provider and sets up important connection details.
@@ -38,14 +39,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "slack",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "slack"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -67,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}
@@ -142,7 +144,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		User struct {
 			NickName string `json:"name"`
 			ID       string `json:"id"`
-			Profile  struct {
+			Profile struct {
 				Email     string `json:"email"`
 				Name      string `json:"real_name"`
 				AvatarURL string `json:"image_32"`

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -23,12 +23,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Slack.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Slack provider and sets up important connection details.
@@ -36,18 +36,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "slack",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "slack",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -69,7 +74,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -23,12 +23,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Soundcloud.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Soundcloud provider and sets up important connection details.
@@ -36,18 +36,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "soundcloud",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "soundcloud",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -69,7 +74,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -28,6 +28,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Soundcloud provider and sets up important connection details.
@@ -38,14 +39,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "soundcloud",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "soundcloud"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -67,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken:  sess.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -55,6 +55,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "spotify",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -67,11 +68,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) Name() string {
-	return "spotify"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -95,7 +97,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
@@ -121,7 +123,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		DisplayName string `json:"display_name"`
 		Email       string `json:"email"`
 		ID          string `json:"id"`
-		Images      []struct {
+		Images []struct {
 			URL string `json:"url"`
 		} `json:"images"`
 	}{}

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -52,10 +52,10 @@ const (
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "spotify",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "spotify",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -63,17 +63,22 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Spotify.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -97,7 +102,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -30,6 +30,7 @@ func New(apiKey string, callbackURL string) *Provider {
 	p := &Provider{
 		APIKey:      apiKey,
 		CallbackURL: callbackURL,
+		Name:        "steam",
 	}
 	return p
 }
@@ -39,11 +40,12 @@ type Provider struct {
 	APIKey      string
 	CallbackURL string
 	HTTPClient  *http.Client
+	Name        string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) Name() string {
-	return "steam"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -98,7 +100,7 @@ func (p *Provider) getAuthURL() (*url.URL, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	u := goth.User{
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 		AccessToken: s.ResponseNonce,
 	}
 

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -28,24 +28,29 @@ const (
 // one manually.
 func New(apiKey string, callbackURL string) *Provider {
 	p := &Provider{
-		APIKey:      apiKey,
-		CallbackURL: callbackURL,
-		Name:        "steam",
+		APIKey:              apiKey,
+		CallbackURL:         callbackURL,
+		providerName:        "steam",
 	}
 	return p
 }
 
 // Provider is the implementation of `goth.Provider` for accessing Steam
 type Provider struct {
-	APIKey      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	Name        string
+	APIKey       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	providerName string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -100,7 +105,7 @@ func (p *Provider) getAuthURL() (*url.URL, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	u := goth.User{
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 		AccessToken: s.ResponseNonce,
 	}
 

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -24,6 +24,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Stripe provider and sets up important connection details.
@@ -34,14 +35,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "stripe",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "stripe"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -63,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
@@ -112,7 +114,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		Name      string `json:"display_name"`
 		AvatarURL string `json:"business_logo"`
 		ID        string `json:"id"`
-		Address   struct {
+		Address struct {
 			Location string `json:"city"`
 		} `json:"support_address"`
 	}{}

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -19,12 +19,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Stripe.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Stripe provider and sets up important connection details.
@@ -32,18 +32,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "stripe",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "stripe",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -62,6 +62,7 @@ func New(clientKey string, secret string, callbackURL string, scopes ...string) 
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "twitch",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -74,11 +75,12 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) Name() string {
-	return "twitch"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -104,7 +106,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -59,10 +59,10 @@ const (
 // one manually.
 func New(clientKey string, secret string, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "twitch",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "twitch",
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -70,17 +70,22 @@ func New(clientKey string, secret string, callbackURL string, scopes ...string) 
 
 // Provider is the implementation of `goth.Provider` for accessing Twitch
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // Name gets the name used to retrieve this provider.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -106,7 +111,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -29,10 +29,10 @@ var (
 // If you'd like to use authenticate instead of authorize, use NewAuthenticate instead.
 func New(clientKey, secret, callbackURL string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "twitter",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "twitter",
 	}
 	p.consumer = newConsumer(p, authorizeURL)
 	return p
@@ -42,10 +42,10 @@ func New(clientKey, secret, callbackURL string) *Provider {
 // NewAuthenticate uses the authenticate URL instead of the authorize URL.
 func NewAuthenticate(clientKey, secret, callbackURL string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "twitter",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "twitter",
 	}
 	p.consumer = newConsumer(p, authenticateURL)
 	return p
@@ -53,18 +53,23 @@ func NewAuthenticate(clientKey, secret, callbackURL string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Twitter.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	debug       bool
-	consumer    *oauth.Consumer
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	debug        bool
+	consumer     *oauth.Consumer
+	providerName string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -90,7 +95,7 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 // FetchUser will go to Twitter and access basic information about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
-		Provider: p.GetName(),
+		Provider: p.Name(),
 	}
 
 	sess := session.(*Session)

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -32,6 +32,7 @@ func New(clientKey, secret, callbackURL string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "twitter",
 	}
 	p.consumer = newConsumer(p, authorizeURL)
 	return p
@@ -44,6 +45,7 @@ func NewAuthenticate(clientKey, secret, callbackURL string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "twitter",
 	}
 	p.consumer = newConsumer(p, authenticateURL)
 	return p
@@ -57,11 +59,12 @@ type Provider struct {
 	HTTPClient  *http.Client
 	debug       bool
 	consumer    *oauth.Consumer
+	Name        string
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "twitter"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -87,7 +90,7 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 // FetchUser will go to Twitter and access basic information about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
-		Provider: p.Name(),
+		Provider: p.GetName(),
 	}
 
 	sess := session.(*Session)

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -24,6 +24,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Uber provider and sets up important connection details.
@@ -34,14 +35,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "uber",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "uber"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -63,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -19,12 +19,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Uber.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Uber provider and sets up important connection details.
@@ -32,18 +32,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "uber",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "uber",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -26,6 +26,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Wepay provider and sets up important connection details.
@@ -36,14 +37,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "wepay",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "wepay"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +67,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -21,12 +21,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Wepay.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Wepay provider and sets up important connection details.
@@ -34,18 +34,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "wepay",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "wepay",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -67,7 +72,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -24,6 +24,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name string
 }
 
 // New creates a new Yahoo provider and sets up important connection details.
@@ -34,14 +35,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name: "yahoo",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "yahoo"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -63,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.Name(),
+		Provider:     p.GetName(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -19,12 +19,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Yahoo.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Yahoo provider and sets up important connection details.
@@ -32,18 +32,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name: "yahoo",
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "yahoo",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	user := goth.User{
 		AccessToken:  s.AccessToken,
-		Provider:     p.GetName(),
+		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
@@ -113,7 +118,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 			NickName string `json:"nickname"`
 			Location string `json:"location"`
 			ID       string `json:"guid"`
-			Image    struct {
+			Image struct {
 				ImageURL string `json:"imageURL"`
 			} `json:"image"`
 		} `json:"profile"`

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -19,12 +19,12 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Yammer.
 type Provider struct {
-	ClientKey   string
-	Secret      string
-	CallbackURL string
-	HTTPClient  *http.Client
-	config      *oauth2.Config
-	Name        string
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
 }
 
 // New creates a new Yammer provider and sets up important connection details.
@@ -32,18 +32,23 @@ type Provider struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:   clientKey,
-		Secret:      secret,
-		CallbackURL: callbackURL,
-		Name:        "yammer",
+		ClientKey:           clientKey,
+		Secret:              secret,
+		CallbackURL:         callbackURL,
+		providerName:        "yammer",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) GetName() string {
-	return p.Name
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -65,7 +70,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.GetName(),
+		Provider:    p.Name(),
 	}
 	err := populateUser(sess.userMap, &user)
 	return user, err

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -24,6 +24,7 @@ type Provider struct {
 	CallbackURL string
 	HTTPClient  *http.Client
 	config      *oauth2.Config
+	Name        string
 }
 
 // New creates a new Yammer provider and sets up important connection details.
@@ -34,14 +35,15 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		ClientKey:   clientKey,
 		Secret:      secret,
 		CallbackURL: callbackURL,
+		Name:        "yammer",
 	}
 	p.config = newConfig(p, scopes)
 	return p
 }
 
 // Name is the name used to retrieve this provider later.
-func (p *Provider) Name() string {
-	return "yammer"
+func (p *Provider) GetName() string {
+	return p.Name
 }
 
 func (p *Provider) Client() *http.Client {
@@ -63,7 +65,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
 	user := goth.User{
 		AccessToken: sess.AccessToken,
-		Provider:    p.Name(),
+		Provider:    p.GetName(),
 	}
 	err := populateUser(sess.userMap, &user)
 	return user, err


### PR DESCRIPTION
To be able to register the same provider twice we need to be able to override the provider name.
Don't want this to be a new func registered to the provider.Name but be inline with Client ( #123 ) 
Downside is that existing calls to provider.Name() will break (easy to replace with GetName() )

This will maybe also fix issue #126 ?

