### PR TITLE
Get user without reauthenticating

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -97,10 +97,15 @@ func main() {
 
 		//Auth0 allocates domain per customer, a domain must be provided for auth0 to work
 		auth0.New(os.Getenv("AUTH0_KEY"), os.Getenv("AUTH0_SECRET"), "http://localhost:3000/auth/auth0/callback", os.Getenv("AUTH0_DOMAIN")),
-
-		//OpenID Connect is based on OpenID Connect Auto Discovery URL (https://openid.net/specs/openid-connect-discovery-1_0-17.html)
-		openidConnect.New(os.Getenv("OPENID_CONNECT_KEY"), os.Getenv("OPENID_CONNECT_SECRET"), "http://localhost:3000/auth/openid-connect/callback", os.Getenv("OPENID_CONNECT_DISCOVERY_URL")),
 	)
+
+	// OpenID Connect is based on OpenID Connect Auto Discovery URL (https://openid.net/specs/openid-connect-discovery-1_0-17.html)
+	// because the OpenID Connect provider initialize it self in the New(), it can return an error which should be handled or ignored
+	// ignore the error for now
+	openidConnect, _ := openidConnect.New(os.Getenv("OPENID_CONNECT_KEY"), os.Getenv("OPENID_CONNECT_SECRET"), "http://localhost:3000/auth/openid-connect/callback", os.Getenv("OPENID_CONNECT_DISCOVERY_URL"))
+	if openidConnect != nil {
+		goth.UseProviders(openidConnect)
+	}
 
 	m := make(map[string]string)
 	m["amazon"] = "Amazon"

--- a/examples/main.go
+++ b/examples/main.go
@@ -163,7 +163,16 @@ func main() {
 		t.Execute(res, user)
 	})
 
-	p.Get("/auth/{provider}", gothic.BeginAuthHandler)
+	p.Get("/auth/{provider}", func(res http.ResponseWriter, req *http.Request) {
+		// try to get the user without re-authenticating
+		if gothUser, err := gothic.CompleteUserAuth(res, req); err == nil {
+			t, _ := template.New("foo").Parse(userTemplate)
+			t.Execute(res, gothUser)
+		} else {
+			gothic.BeginAuthHandler(res, req)
+		}
+	})
+
 	p.Get("/", func(res http.ResponseWriter, req *http.Request) {
 		t, _ := template.New("foo").Parse(indexTemplate)
 		t.Execute(res, providerIndex)

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -111,9 +111,8 @@ func GetAuthURL(res http.ResponseWriter, req *http.Request) (string, error) {
 		return "", err
 	}
 
-	session, _ := Store.Get(req, SessionName)
-	session.Values[SessionName] = sess.Marshal()
-	err = session.Save(req, res)
+	err = storeInSession(providerName, sess.Marshal(), req, res)
+
 	if err != nil {
 		return "", err
 	}
@@ -146,18 +145,29 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 		return goth.User{}, err
 	}
 
-	session, _ := Store.Get(req, SessionName)
-
-	if session.Values[SessionName] == nil {
-		return goth.User{}, errors.New("could not find a matching session for this request")
-	}
-
-	sess, err := provider.UnmarshalSession(session.Values[SessionName].(string))
+	value, err := getFromSession(providerName, req)
 	if err != nil {
 		return goth.User{}, err
 	}
 
+	sess, err := provider.UnmarshalSession(value)
+	if err != nil {
+		return goth.User{}, err
+	}
+
+	user, err := provider.FetchUser(sess)
+	if err == nil {
+		// user can be found with existing session data
+		return user, err
+	}
+
+	// get new token and retry fetch
 	_, err = sess.Authorize(provider, req.URL.Query())
+	if err != nil {
+		return goth.User{}, err
+	}
+
+	err = storeInSession(providerName, sess.Marshal(), req, res)
 
 	if err != nil {
 		return goth.User{}, err
@@ -187,4 +197,31 @@ func getProviderName(req *http.Request) (string, error) {
 		return provider, errors.New("you must select a provider")
 	}
 	return provider, nil
+}
+
+func storeInSession(key string, value string, req *http.Request, res http.ResponseWriter) error {
+	session, err := Store.Get(req, key + SessionName)
+	if err != nil {
+		return err
+	}
+
+	session.Values[key] = value
+
+	err = session.Save(req, res)
+
+	return err
+}
+
+func getFromSession(key string, req *http.Request) (string, error) {
+	session, err := Store.Get(req, key + SessionName)
+	if err != nil {
+		return "", err
+	}
+
+	value := session.Values[key]
+	if value == nil {
+		return "", errors.New("could not find a matching session for this request")
+	}
+
+	return value.(string), nil
 }

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -200,23 +200,15 @@ func getProviderName(req *http.Request) (string, error) {
 }
 
 func storeInSession(key string, value string, req *http.Request, res http.ResponseWriter) error {
-	session, err := Store.Get(req, key + SessionName)
-	if err != nil {
-		return err
-	}
+	session, _ := Store.Get(req, key + SessionName)
 
 	session.Values[key] = value
 
-	err = session.Save(req, res)
-
-	return err
+	return session.Save(req, res)
 }
 
 func getFromSession(key string, req *http.Request) (string, error) {
-	session, err := Store.Get(req, key + SessionName)
-	if err != nil {
-		return "", err
-	}
+	session, _ := Store.Get(req, key + SessionName)
 
 	value := session.Values[key]
 	if value == nil {

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -87,8 +87,8 @@ func Test_CompleteUserAuth(t *testing.T) {
 	a.NoError(err)
 
 	sess := faux.Session{Name: "Homer Simpson", Email: "homer@example.com"}
-	session, _ := Store.Get(req, SessionName)
-	session.Values[SessionName] = sess.Marshal()
+	session, _ := Store.Get(req, "faux" + SessionName)
+	session.Values["faux"] = sess.Marshal()
 	err = session.Save(req, res)
 	a.NoError(err)
 

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -76,6 +77,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := goth.HTTPClientWithFallBack(p.Client()).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -91,6 +91,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -89,6 +90,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	userProfileURL := protocol + p.Domain + endpointProfile
 	req, err := http.NewRequest("GET", userProfileURL, nil)
 	if err != nil {

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -111,6 +111,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/auth0/auth0_test.go
+++ b/providers/auth0/auth0_test.go
@@ -86,12 +86,14 @@ func Test_FetchUser(t *testing.T) {
 	p := provider()
 	session, err := p.BeginAuth("test_state")
 	s := session.(*auth0.Session)
+	s.AccessToken = "token"
 	u, err := p.FetchUser(s)
 	a.Nil(err)
 	a.Equal(u.Email, "test.account@userinfo.com")
 	a.Equal(u.UserID, "auth0|58454...")
 	a.Equal(u.NickName, "test.account")
 	a.Equal(u.Name, "test.account@userinfo.com")
+	a.Equal("token", u.AccessToken)
 
 }
 

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -78,6 +79,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := goth.HTTPClientWithFallBack(p.Client()).Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -92,6 +92,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -92,6 +92,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -74,6 +75,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
 		return user, err

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -100,6 +100,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return user, err

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -13,6 +13,7 @@ import (
 	"github.com/markbates/goth"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 // Provider is the implementation of `goth.Provider` for accessing Cloud Foundry.
@@ -79,6 +80,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", p.UserInfoURL, nil)
 	if err != nil {
 		return user, err

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -93,6 +93,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -76,6 +77,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -93,6 +93,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -76,6 +77,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
 		ExpiresAt:   sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -101,6 +101,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return user, err

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -80,6 +81,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	req, err := http.NewRequest("GET", endpointProfile, nil)

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -124,6 +124,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return user, err

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"net/http"
+	"fmt"
 )
 
 const (
@@ -101,6 +102,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -97,6 +97,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -79,6 +80,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: s.Token,
 		Provider:    p.Name(),
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", accountURL, nil)
 	if err != nil {
 		return user, err

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -78,6 +79,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
 		ExpiresAt:   sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endpointProfile + "&access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -92,6 +92,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -118,6 +118,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	//err = userFromReader(io.TeeReader(resp.Body, os.Stdout), &user)
 	err = userFromReader(resp.Body, &user)
 	return user, err

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -97,6 +98,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 		UserID:       s.UserID,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	req, err := http.NewRequest("GET", endpointProfile, nil)

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -91,6 +91,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	response, err := p.Client().Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		return user, err

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -102,6 +102,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 // These vars define the Authentication, Token, and Profile URLS for Gitlab. If
@@ -84,6 +85,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -98,6 +98,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -84,6 +85,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -95,6 +95,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -74,6 +75,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
 		return user, err

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -105,6 +105,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	response, err := p.Client().Get(p.UserAPIEndpoint + "?access_token=" + url.QueryEscape(sess.AccessToken))
 
 	if err != nil {

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -120,6 +120,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -93,6 +93,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 var (
@@ -78,6 +79,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user := goth.User{
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endPointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -78,6 +78,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:   sess.ExpiresAt,
 	}
 
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	request, err := http.NewRequest("GET", UserURL, nil)
 	if err != nil {
 		return user, err

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -101,6 +101,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/intercom/intercom_test.go
+++ b/providers/intercom/intercom_test.go
@@ -80,7 +80,7 @@ func Test_FetchUser(t *testing.T) {
 
 	mockIntercomFetchUser(&u, func(ts *httptest.Server) {
 		provider := intercomProvider()
-		session := &intercom.Session{}
+		session := &intercom.Session{AccessToken: "token"}
 
 		user, err := provider.FetchUser(session)
 		a.NoError(err)
@@ -92,6 +92,7 @@ func Test_FetchUser(t *testing.T) {
 		a.Equal("Washburne", user.LastName)
 		a.Equal("http://avatarURL", user.AvatarURL)
 		a.Equal(true, user.RawData["email_verified"])
+		a.Equal("token", user.AccessToken)
 	})
 }
 
@@ -107,7 +108,7 @@ func Test_FetchUnverifiedUser(t *testing.T) {
 
 	mockIntercomFetchUser(&u, func(ts *httptest.Server) {
 		provider := intercomProvider()
-		session := &intercom.Session{}
+		session := &intercom.Session{AccessToken: "token"}
 
 		user, err := provider.FetchUser(session)
 		a.NoError(err)
@@ -119,6 +120,7 @@ func Test_FetchUnverifiedUser(t *testing.T) {
 		a.Equal("Washburne", user.LastName)
 		a.Equal("http://avatarURL", user.AvatarURL)
 		a.Equal(false, user.RawData["email_verified"])
+		a.Equal("token", user.AccessToken)
 	})
 }
 

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -83,6 +83,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:    p.Name(),
 	}
 
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s has no user information available (yet)", p.providerName)
+	}
+
 	u := struct {
 		XMLName    xml.Name `xml:"user"`
 		ID         string   `xml:"id"`

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -106,6 +106,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	//err = userFromReader(io.TeeReader(resp.Body, os.Stdout), &user)
 	err = userFromReader(resp.Body, &user)
 	return user, err

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 //more details about linkedin fields: https://developer.linkedin.com/documents/profile-fields
@@ -79,6 +80,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: s.AccessToken,
 		Provider:    p.Name(),
 		ExpiresAt:   s.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	req, err := http.NewRequest("GET", "", nil)

--- a/providers/meetup/meetup.go
+++ b/providers/meetup/meetup.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"io"
 	"strconv"
+	"fmt"
 )
 
 const (
@@ -81,6 +82,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		ExpiresAt:    sess.ExpiresAt,
 	}
 
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	request, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
 		return user, err
@@ -92,6 +98,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
 
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -76,6 +77,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -90,6 +90,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -143,6 +143,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	expiresAt := sess.ExpiresAt
 
+	if sess.IDToken == "" {
+		return goth.User{}, fmt.Errorf("%s cannot get user information without id_token", p.providerName)
+	}
+
 	// decode returned id token to get expiry
 	claims, err := decodeJWT(sess.IDToken)
 

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -83,7 +83,7 @@ type OpenIDConfig struct {
 // See http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
 // ID Token decryption is not (yet) supported
 // UserInfo decryption is not (yet) supported
-func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes ...string) *Provider {
+func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes ...string) (*Provider, error) {
 	p := &Provider{
 		ClientKey:   clientKey,
 		Secret:      secret,
@@ -103,12 +103,12 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 
 	openIDConfig, err := getOpenIDConfig(p, openIDAutoDiscoveryURL)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	p.openIDConfig = openIDConfig
 
 	p.config = newConfig(p, scopes, openIDConfig)
-	return p
+	return p, nil
 }
 
 // Name is the name used to retrieve this provider later.

--- a/providers/openidConnect/openidConnect_test.go
+++ b/providers/openidConnect/openidConnect_test.go
@@ -73,5 +73,6 @@ func Test_SessionFromJSON(t *testing.T) {
 }
 
 func openidConnectProvider() *Provider {
-	return New(os.Getenv("OPENID_CONNECT_KEY"), os.Getenv("OPENID_CONNECT_SECRET"), "http://localhost/foo", server.URL)
+	provider, _ := New(os.Getenv("OPENID_CONNECT_KEY"), os.Getenv("OPENID_CONNECT_SECRET"), "http://localhost/foo", server.URL)
+	return provider
 }

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -86,6 +87,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	paypalEnv := os.Getenv(envKey)

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -113,6 +113,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -96,6 +96,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -75,6 +76,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	url, err := url.Parse(s.ID)
 	//creating dynamic url to retrieve user information
 	userURL := url.Scheme + "://" + url.Host + "/" + url.Path

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -78,6 +79,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	// Get the userID, slack needs userID in order to get user profile info
 	response, err := p.Client().Get(endpointUser + "?token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -94,6 +94,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -95,6 +95,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return user, err

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -77,6 +78,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: sess.RefreshToken,
 		ExpiresAt:    sess.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	response, err := p.Client().Get(endpointProfile + "?oauth_token=" + url.QueryEscape(sess.AccessToken))

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -105,6 +106,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -123,6 +123,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	//err = userFromReader(io.TeeReader(resp.Body, os.Stdout), &user)
 	err = userFromReader(resp.Body, &user)
 	return user, err

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -128,6 +128,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return u, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return u, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	u, err = buildUserObject(resp.Body, u)
 
 	return u, err

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -109,6 +109,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: s.ResponseNonce,
 	}
 
+	if s.SteamID == "" {
+		// data is not yet retrieved since SteamID is still empty
+		return u, fmt.Errorf("%s cannot get user information without SteamID", p.providerName)
+	}
+
 	apiURL := fmt.Sprintf(apiUserSummaryEndpoint, p.APIKey, s.SteamID)
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -74,6 +75,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", endPointAccount+s.ID, nil)
 	if err != nil {
 		return user, err

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -95,6 +95,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 
 	return user, err

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -134,6 +134,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -114,6 +115,11 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		Provider:     p.Name(),
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
 	req, err := http.NewRequest("GET", userEndpoint, nil)

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/markbates/goth"
 	"github.com/mrjones/oauth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 var (
@@ -94,11 +95,16 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 
 // FetchUser will go to Twitter and access basic information about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	sess := session.(*Session)
 	user := goth.User{
 		Provider: p.Name(),
 	}
 
-	sess := session.(*Session)
+	if sess.AccessToken == nil {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	response, err := p.consumer.Get(
 		endpointProfile,
 		map[string]string{"include_entities": "false", "skip_status": "true"},

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -114,6 +114,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
 	bits, err := ioutil.ReadAll(response.Body)
 	err = json.NewDecoder(bytes.NewReader(bits)).Decode(&user.RawData)
 	if err != nil {

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -95,6 +95,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -74,6 +75,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
 		return user, err

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -97,6 +97,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -76,6 +77,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
 		return user, err

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -95,6 +95,10 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
 	err = userFromReader(resp.Body, &user)
 	return user, err
 }

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -74,6 +75,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	req, err := http.NewRequest("GET", endpointProfile, nil)
 	if err != nil {
 		return user, err

--- a/providers/yammer/session.go
+++ b/providers/yammer/session.go
@@ -17,7 +17,6 @@ import (
 type Session struct {
 	AuthURL     string
 	AccessToken string
-	userMap     map[string]interface{} //stores yammer user detail in map
 }
 
 var _ goth.Session = &Session{}
@@ -48,7 +47,6 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 	token := autData["access_token"]["token"].(string)
 	s.AccessToken = token
-	s.userMap = autData["user"]
 	return token, err
 }
 

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
+	"fmt"
 )
 
 const (
@@ -72,6 +73,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		AccessToken: sess.AccessToken,
 		Provider:    p.Name(),
 	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
 	err := populateUser(sess.userMap, &user)
 	return user, err
 }


### PR DESCRIPTION
PR for issue #132 
Updated the example with the way users can first check if the user is already authenticated and has a valid session

To make it work with all providers I have added checks in the FetchUser methods to check if the accessToken is set and if set, if retrieval of the provider User was successful

The Yammer provider is updated to use the Yammer current user API to get the user information. This way it can work like the other OAuth providers (otherwise to determine if the session was still valid would become to difficult)

Additional fix inside this PR is the example of OpenID Connect which seems to be broken when no settings where given