### PR TITLE
example update to prevent "securecookie: the value is too long"

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -48,10 +48,20 @@ import (
 	"github.com/markbates/goth/providers/openidConnect"
 	"github.com/markbates/goth/providers/meetup"
 	"log"
+	"math"
 )
 
 func init() {
-	gothic.Store = sessions.NewFilesystemStore(os.TempDir(), []byte("goth-example"))
+	store := sessions.NewFilesystemStore(os.TempDir(), []byte("goth-example"))
+
+	// set the maxLength of the cookies stored on the disk to a larger number to prevent issues with:
+	// securecookie: the value is too long
+	// when using OpenID Connect , since this can contain a large amount of extra information in the id_token
+
+	// Note, when using the FilesystemStore only the session.ID is written to a browser cookie, so this is explicit for the storage on disk
+	store.MaxLength(math.MaxInt64)
+
+	gothic.Store = store
 }
 
 func main() {


### PR DESCRIPTION
I have updated the example to show how to prevent "securecookie: the value is too long" exceptions