### PR TITLE
Customise urls non global

### DIFF
--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -37,11 +37,20 @@ var (
 // You should always call `github.New` to get a new Provider. Never try to create
 // one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	return NewCustomisedURL(clientKey, secret, callbackURL, AuthURL, TokenURL, ProfileURL, EmailURL, scopes...)
+}
+
+// NewCustomisedURL is similar to New(...) but can be used to set custom URLs to connect to
+func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, profileURL, emailURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:           clientKey,
-		Secret:              secret,
-		CallbackURL:         callbackURL,
-		providerName:        "github",
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "github",
+		authURL:      authURL,
+		tokenURL:     tokenURL,
+		profileURL:   profileURL,
+		emailURL:     emailURL,
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -55,6 +64,10 @@ type Provider struct {
 	HTTPClient   *http.Client
 	config       *oauth2.Config
 	providerName string
+	authURL      string
+	tokenURL     string
+	profileURL   string
+	emailURL     string
 }
 
 // Name is the name used to retrieve this provider later.
@@ -96,7 +109,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
-	response, err := p.Client().Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := p.Client().Get(p.profileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		return user, err
 	}
@@ -163,7 +176,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 }
 
 func getPrivateMail(p *Provider, sess *Session) (email string, err error) {
-	response, err := p.Client().Get(EmailURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := p.Client().Get(p.emailURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -200,8 +213,8 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 		ClientSecret: provider.Secret,
 		RedirectURL:  provider.CallbackURL,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  AuthURL,
-			TokenURL: TokenURL,
+			AuthURL:  provider.authURL,
+			TokenURL: provider.tokenURL,
 		},
 		Scopes: []string{},
 	}

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -47,12 +47,10 @@ func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, profile
 		Secret:       secret,
 		CallbackURL:  callbackURL,
 		providerName: "github",
-		authURL:      authURL,
-		tokenURL:     tokenURL,
 		profileURL:   profileURL,
 		emailURL:     emailURL,
 	}
-	p.config = newConfig(p, scopes)
+	p.config = newConfig(p, authURL, tokenURL, scopes)
 	return p
 }
 
@@ -64,8 +62,6 @@ type Provider struct {
 	HTTPClient   *http.Client
 	config       *oauth2.Config
 	providerName string
-	authURL      string
-	tokenURL     string
 	profileURL   string
 	emailURL     string
 }
@@ -207,14 +203,14 @@ func getPrivateMail(p *Provider, sess *Session) (email string, err error) {
 	return
 }
 
-func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+func newConfig(provider *Provider, authURL, tokenURL string, scopes []string) *oauth2.Config {
 	c := &oauth2.Config{
 		ClientID:     provider.ClientKey,
 		ClientSecret: provider.Secret,
 		RedirectURL:  provider.CallbackURL,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  provider.authURL,
-			TokenURL: provider.tokenURL,
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
 		},
 		Scopes: []string{},
 	}

--- a/providers/github/github_test.go
+++ b/providers/github/github_test.go
@@ -20,6 +20,16 @@ func Test_New(t *testing.T) {
 	a.Equal(provider.CallbackURL, "/foo")
 }
 
+func Test_NewCustomisedURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := urlCustomisedURLProvider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*github.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "http://authURL")
+}
+
 func Test_Implements_Provider(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
@@ -56,4 +66,8 @@ func Test_SessionFromJSON(t *testing.T) {
 
 func githubProvider() *github.Provider {
 	return github.New(os.Getenv("GITHUB_KEY"), os.Getenv("GITHUB_SECRET"), "/foo", "user")
+}
+
+func urlCustomisedURLProvider() *github.Provider {
+	return github.NewCustomisedURL(os.Getenv("GITHUB_KEY"), os.Getenv("GITHUB_SECRET"), "/foo", "http://authURL", "http://tokenURL", "http://profileURL", "http://emailURL")
 }

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -56,11 +56,9 @@ func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, profile
 		Secret:       secret,
 		CallbackURL:  callbackURL,
 		providerName: "gitlab",
-		authURL:      authURL,
-		tokenURL:     tokenURL,
 		profileURL:   profileURL,
 	}
-	p.config = newConfig(p, scopes)
+	p.config = newConfig(p, authURL, tokenURL, scopes)
 	return p
 }
 
@@ -132,14 +130,14 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	return user, err
 }
 
-func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+func newConfig(provider *Provider, authURL, tokenURL string, scopes []string) *oauth2.Config {
 	c := &oauth2.Config{
 		ClientID:     provider.ClientKey,
 		ClientSecret: provider.Secret,
 		RedirectURL:  provider.CallbackURL,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  provider.authURL,
-			TokenURL: provider.tokenURL,
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
 		},
 		Scopes: []string{},
 	}

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -37,17 +37,28 @@ type Provider struct {
 	HTTPClient   *http.Client
 	config       *oauth2.Config
 	providerName string
+	authURL      string
+	tokenURL     string
+	profileURL   string
 }
 
 // New creates a new Gitlab provider and sets up important connection details.
 // You should always call `gitlab.New` to get a new provider.  Never try to
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	return NewCustomisedURL(clientKey, secret, callbackURL, AuthURL, TokenURL, ProfileURL, scopes...)
+}
+
+// NewCustomisedURL is similar to New(...) but can be used to set custom URLs to connect to
+func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, profileURL string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:           clientKey,
-		Secret:              secret,
-		CallbackURL:         callbackURL,
-		providerName:        "gitlab",
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "gitlab",
+		authURL:      authURL,
+		tokenURL:     tokenURL,
+		profileURL:   profileURL,
 	}
 	p.config = newConfig(p, scopes)
 	return p
@@ -92,7 +103,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
-	response, err := p.Client().Get(ProfileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := p.Client().Get(p.profileURL + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -127,8 +138,8 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 		ClientSecret: provider.Secret,
 		RedirectURL:  provider.CallbackURL,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  AuthURL,
-			TokenURL: TokenURL,
+			AuthURL:  provider.authURL,
+			TokenURL: provider.tokenURL,
 		},
 		Scopes: []string{},
 	}

--- a/providers/gitlab/gitlab_test.go
+++ b/providers/gitlab/gitlab_test.go
@@ -1,11 +1,12 @@
 package gitlab_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/gitlab"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func Test_New(t *testing.T) {
@@ -16,6 +17,16 @@ func Test_New(t *testing.T) {
 	a.Equal(p.ClientKey, os.Getenv("GITLAB_KEY"))
 	a.Equal(p.Secret, os.Getenv("GITLAB_SECRET"))
 	a.Equal(p.CallbackURL, "/foo")
+}
+
+func Test_NewCustomisedURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := urlCustomisedURLProvider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*gitlab.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "http://authURL")
 }
 
 func Test_Implements_Provider(t *testing.T) {
@@ -49,4 +60,8 @@ func Test_SessionFromJSON(t *testing.T) {
 
 func provider() *gitlab.Provider {
 	return gitlab.New(os.Getenv("GITLAB_KEY"), os.Getenv("GITLAB_SECRET"), "/foo")
+}
+
+func urlCustomisedURLProvider() *gitlab.Provider {
+	return gitlab.NewCustomisedURL(os.Getenv("GITLAB_KEY"), os.Getenv("GITLAB_SECRET"), "/foo", "http://authURL", "http://tokenURL", "http://profileURL")
 }

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -40,6 +40,11 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	authURL := fmt.Sprintf("https://%s%s", domain, authPath)
 	userAPIEndpoint := fmt.Sprintf("https://%s%s", domain, userAPIPath)
 
+	return NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, userAPIEndpoint, scopes...)
+}
+
+// NewCustomisedURL is similar to New(...) but can be used to set custom URLs to connect to
+func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, userAPIEndpoint string, scopes ...string) *Provider {
 	p := &Provider{
 		ClientKey:       clientKey,
 		Secret:          secret,

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -5,6 +5,7 @@ package paypal
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,12 +14,11 @@ import (
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
-	"fmt"
 )
 
 const (
-	sandox string = "sandbox"
-	envKey string = "PAYPAL_ENV"
+	sandbox string = "sandbox"
+	envKey  string = "PAYPAL_ENV"
 
 	//Endpoints for paypal sandbox env
 	authURLSandbox         string = "https://www.sandbox.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize"
@@ -39,19 +39,38 @@ type Provider struct {
 	HTTPClient   *http.Client
 	config       *oauth2.Config
 	providerName string
+	profileURL   string
 }
 
 // New creates a new Paypal provider and sets up important connection details.
 // You should always call `paypal.New` to get a new provider.  Never try to
 // create one manually.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
-	p := &Provider{
-		ClientKey:           clientKey,
-		Secret:              secret,
-		CallbackURL:         callbackURL,
-		providerName:        "paypal",
+	paypalEnv := os.Getenv(envKey)
+
+	authURL := authURLProduction
+	tokenURL := tokenURLProduction
+	profileEndPoint := endpointProfileProduction
+
+	if paypalEnv == sandbox {
+		authURL = authURLSandbox
+		tokenURL = tokenURLSandbox
+		profileEndPoint = endpointProfileSandbox
 	}
-	p.config = newConfig(p, scopes)
+
+	return NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, profileEndPoint, scopes...)
+}
+
+// NewCustomisedURL is similar to New(...) but can be used to set custom URLs to connect to
+func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, profileURL string, scopes ...string) *Provider {
+	p := &Provider{
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "paypal",
+		profileURL:   profileURL,
+	}
+	p.config = newConfig(p, authURL, tokenURL, scopes)
 	return p
 }
 
@@ -94,17 +113,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
-	paypalEnv := os.Getenv(envKey)
-
-	profileEndPoint := ""
-
-	if paypalEnv != "" && paypalEnv == sandox {
-		profileEndPoint = endpointProfileSandbox
-	} else {
-		profileEndPoint = endpointProfileProduction
-	}
-
-	response, err := p.Client().Get(profileEndPoint + "?schema=openid&access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := p.Client().Get(p.profileURL + "?schema=openid&access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		if response != nil {
 			response.Body.Close()
@@ -132,21 +141,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	return user, err
 }
 
-func newConfig(provider *Provider, scopes []string) *oauth2.Config {
-
-	paypalEnv := os.Getenv(envKey)
-
-	authURL := ""
-	tokenURL := ""
-
-	if paypalEnv != "" && paypalEnv == sandox {
-		authURL = authURLSandbox
-		tokenURL = tokenURLSandbox
-	} else {
-		authURL = authURLProduction
-		tokenURL = tokenURLProduction
-	}
-
+func newConfig(provider *Provider, authURL, tokenURL string, scopes []string) *oauth2.Config {
 	c := &oauth2.Config{
 		ClientID:     provider.ClientKey,
 		ClientSecret: provider.Secret,

--- a/providers/paypal/paypal_test.go
+++ b/providers/paypal/paypal_test.go
@@ -1,11 +1,12 @@
 package paypal_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/paypal"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func Test_New(t *testing.T) {
@@ -16,6 +17,16 @@ func Test_New(t *testing.T) {
 	a.Equal(p.ClientKey, os.Getenv("PAYPAL_KEY"))
 	a.Equal(p.Secret, os.Getenv("PAYPAL_SECRET"))
 	a.Equal(p.CallbackURL, "/foo")
+}
+
+func Test_NewCustomisedURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := urlCustomisedURLProvider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*paypal.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "http://authURL")
 }
 
 func Test_Implements_Provider(t *testing.T) {
@@ -49,4 +60,8 @@ func Test_SessionFromJSON(t *testing.T) {
 
 func provider() *paypal.Provider {
 	return paypal.New(os.Getenv("PAYPAL_KEY"), os.Getenv("PAYPAL_SECRET"), "/foo")
+}
+
+func urlCustomisedURLProvider() *paypal.Provider {
+	return paypal.NewCustomisedURL(os.Getenv("PAYPAL_KEY"), os.Getenv("PAYPAL_SECRET"), "/foo", "http://authURL", "http://tokenURL", "http://profileURL")
 }


### PR DESCRIPTION
Fixes #143 so that urls can be given for each provider instance instead of set globally (which is a problem with multiple instances of 1 provider type)