### PR TITLE
Added state token checks to prevent CSRF

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -180,9 +180,8 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 	return provider.FetchUser(sess)
 }
 
-// validateState checks whether a state token was stored
-// with the original session and, if so, makes sure that
-// the current request contains a matching state value.
+// validateState ensures that the state token param from the original
+// AuthURL matches the one included in the current (callback) request.
 func validateState(req *http.Request, sess goth.Session) error {
 	rawAuthURL, err := sess.GetAuthURL()
 	if err != nil {
@@ -194,8 +193,7 @@ func validateState(req *http.Request, sess goth.Session) error {
 		return err
 	}
 
-	state := authURL.Query().Get("state")
-	if state != "" && state != req.URL.Query().Get("state") {
+	if authURL.Query().Get("state") != req.URL.Query().Get("state") {
 		return errors.New("state token mismatch")
 	}
 	return nil

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/gorilla/mux"
@@ -87,7 +88,6 @@ I would recommend using the BeginAuthHandler instead of doing all of these steps
 yourself, but that's entirely up to you.
 */
 func GetAuthURL(res http.ResponseWriter, req *http.Request) (string, error) {
-
 	if !keySet && defaultStore == Store {
 		fmt.Println("goth/gothic: no SESSION_SECRET environment variable is set. The default cookie store is not available and any calls will fail. Ignore this warning if you are using a different store.")
 	}
@@ -130,7 +130,6 @@ as either "provider" or ":provider".
 See https://github.com/markbates/goth/examples/main.go to see this in action.
 */
 var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.User, error) {
-
 	if !keySet && defaultStore == Store {
 		fmt.Println("goth/gothic: no SESSION_SECRET environment variable is set. The default cookie store is not available and any calls will fail. Ignore this warning if you are using a different store.")
 	}
@@ -151,6 +150,11 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 	}
 
 	sess, err := provider.UnmarshalSession(value)
+	if err != nil {
+		return goth.User{}, err
+	}
+
+	err = validateState(req, sess)
 	if err != nil {
 		return goth.User{}, err
 	}
@@ -176,9 +180,29 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 	return provider.FetchUser(sess)
 }
 
+// validateState checks whether a state token was stored
+// with the original session and, if so, makes sure that
+// the current request contains a matching state value.
+func validateState(req *http.Request, sess goth.Session) error {
+	rawAuthURL, err := sess.GetAuthURL()
+	if err != nil {
+		return err
+	}
+
+	authURL, err := url.Parse(rawAuthURL)
+	if err != nil {
+		return err
+	}
+
+	state := authURL.Query().Get("state")
+	if state != "" && state != req.URL.Query().Get("state") {
+		return errors.New("state token mismatch")
+	}
+	return nil
+}
+
 // Logout invalidates a user session.
 func Logout(res http.ResponseWriter, req *http.Request) error {
-
 	providerName, err := GetProviderName(req)
 	if err != nil {
 		return err
@@ -209,7 +233,7 @@ func getProviderName(req *http.Request) (string, error) {
 	if p := req.URL.Query().Get("provider"); p != "" {
 		return p, nil
 	}
-	
+
 	// try to get it from the url param ":provider"
 	if p := req.URL.Query().Get(":provider"); p != "" {
 		return p, nil

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -3,7 +3,6 @@ package gothic_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gorilla/sessions"
@@ -32,6 +31,10 @@ func (p ProviderStore) Get(r *http.Request, name string) (*sessions.Session, err
 
 func (p ProviderStore) New(r *http.Request, name string) (*sessions.Session, error) {
 	s := sessions.NewSession(p, name)
+	s.Options = &sessions.Options{
+		Path:   "/",
+		MaxAge: 86400 * 30,
+	}
 	p.Store[r] = s
 	return s, nil
 }
@@ -42,13 +45,11 @@ func (p ProviderStore) Save(r *http.Request, w http.ResponseWriter, s *sessions.
 }
 
 func init() {
-	Store = sessions.NewFilesystemStore(os.TempDir(), []byte("goth-test"))
+	Store = NewProviderStore()
 	goth.UseProviders(&faux.Provider{})
 }
 
 func Test_BeginAuthHandler(t *testing.T) {
-	t.Parallel()
-
 	a := assert.New(t)
 
 	res := httptest.NewRecorder()
@@ -58,12 +59,11 @@ func Test_BeginAuthHandler(t *testing.T) {
 	BeginAuthHandler(res, req)
 
 	a.Equal(http.StatusTemporaryRedirect, res.Code)
-	a.Contains(res.Body.String(), `<a href="http://example.com/auth/">Temporary Redirect</a>`)
+	a.Contains(res.Body.String(),
+		`<a href="http://example.com/auth?client_id=&amp;response_type=code&amp;state=state">Temporary Redirect</a>`)
 }
 
 func Test_GetAuthURL(t *testing.T) {
-	t.Parallel()
-
 	a := assert.New(t)
 
 	res := httptest.NewRecorder()
@@ -74,12 +74,10 @@ func Test_GetAuthURL(t *testing.T) {
 
 	a.NoError(err)
 
-	a.Equal("http://example.com/auth/", url)
+	a.Equal("http://example.com/auth?client_id=&response_type=code&state=state", url)
 }
 
 func Test_CompleteUserAuth(t *testing.T) {
-	t.Parallel()
-
 	a := assert.New(t)
 
 	res := httptest.NewRecorder()
@@ -100,8 +98,6 @@ func Test_CompleteUserAuth(t *testing.T) {
 }
 
 func Test_Logout(t *testing.T) {
-	t.Parallel()
-
 	a := assert.New(t)
 
 	res := httptest.NewRecorder()
@@ -127,8 +123,6 @@ func Test_Logout(t *testing.T) {
 }
 
 func Test_SetState(t *testing.T) {
-	t.Parallel()
-
 	a := assert.New(t)
 
 	req, _ := http.NewRequest("GET", "/auth?state=state", nil)
@@ -136,10 +130,32 @@ func Test_SetState(t *testing.T) {
 }
 
 func Test_GetState(t *testing.T) {
-	t.Parallel()
-
 	a := assert.New(t)
 
 	req, _ := http.NewRequest("GET", "/auth?state=state", nil)
 	a.Equal(GetState(req), "state")
+}
+
+func Test_StateValidation(t *testing.T) {
+	a := assert.New(t)
+
+	Store = NewProviderStore()
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/auth?provider=faux&state=state_REAL", nil)
+	a.NoError(err)
+
+	BeginAuthHandler(res, req)
+	session, _ := Store.Get(req, "faux"+SessionName)
+
+	// Assert that matching states will return a nil error
+	req, err = http.NewRequest("GET", "/auth/callback?provider=faux&state=state_REAL", nil)
+	session.Save(req, res)
+	_, err = CompleteUserAuth(res, req)
+	a.NoError(err)
+
+	// Assert that mismatched states will return an error
+	req, err = http.NewRequest("GET", "/auth/callback?provider=faux&state=state_FAKE", nil)
+	session.Save(req, res)
+	_, err = CompleteUserAuth(res, req)
+	a.Error(err)
 }

--- a/providers/faux/faux.go
+++ b/providers/faux/faux.go
@@ -4,6 +4,7 @@ package faux
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -19,9 +20,11 @@ type Provider struct {
 
 // Session is used only for testing.
 type Session struct {
-	ID    string
-	Name  string
-	Email string
+	ID          string
+	Name        string
+	Email       string
+	AuthURL     string
+	AccessToken string
 }
 
 // Name is used only for testing.
@@ -36,17 +39,33 @@ func (p *Provider) SetName(name string) {
 
 // BeginAuth is used only for testing.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
-	return &Session{ID: "id"}, nil
+	c := &oauth2.Config{
+		Endpoint: oauth2.Endpoint{
+			AuthURL: "http://example.com/auth",
+		},
+	}
+	url := c.AuthCodeURL(state)
+	return &Session{
+		ID:      "id",
+		AuthURL: url,
+	}, nil
 }
 
 // FetchUser is used only for testing.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	sess := session.(*Session)
-	return goth.User{
-		UserID: sess.ID,
-		Name:   sess.Name,
-		Email:  sess.Email,
-	}, nil
+	user := goth.User{
+		UserID:      sess.ID,
+		Name:        sess.Name,
+		Email:       sess.Email,
+		Provider:    p.Name(),
+		AccessToken: sess.AccessToken,
+	}
+
+	if user.AccessToken == "" {
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+	return user, nil
 }
 
 // UnmarshalSession is used only for testing.
@@ -63,11 +82,6 @@ func (p *Provider) Client() *http.Client {
 // Debug is used only for testing.
 func (p *Provider) Debug(debug bool) {}
 
-// Authorize is used only for testing.
-func (p *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
-	return "", nil
-}
-
 //RefreshTokenAvailable is used only for testing
 func (p *Provider) RefreshTokenAvailable() bool {
 	return false
@@ -78,13 +92,19 @@ func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, nil
 }
 
+// Authorize is used only for testing.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	s.AccessToken = "access"
+	return s.AccessToken, nil
+}
+
 // Marshal is used only for testing.
-func (p *Session) Marshal() string {
-	b, _ := json.Marshal(p)
+func (s *Session) Marshal() string {
+	b, _ := json.Marshal(s)
 	return string(b)
 }
 
 // GetAuthURL is used only for testing.
-func (p *Session) GetAuthURL() (string, error) {
-	return "http://example.com/auth/", nil
+func (s *Session) GetAuthURL() (string, error) {
+	return s.AuthURL, nil
 }


### PR DESCRIPTION
This pull request adds a state token check to prevent CSRF attacks.

The check runs during CompleteUserAuth(), immediately after the original session has been unmarshalled. The original state token can be pulled from goth.Session.GetAuthURL()'s query params, so no changes to individual providers appears to be needed.

I've added a test that covers both matching and mismatching state tokens. To get the test to run, I needed to added a bit more detail to the faux provider, change the test Store to use the dummy ProviderStore (so I could simulate setting cookies on incoming requests), and disable parallel execution of tests. The tests still run on my system in 0.012s, so I'm hoping that's not an issue.