### PR TITLE
Added support to get provider name from request URL's go context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.5
-  - 1.6
   - 1.7
+  - 1.8
   - tip
 
 matrix:

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -246,6 +246,11 @@ func getProviderName(req *http.Request) (string, error) {
 		return p, nil
 	}
 
+	//  try to get it from the go-context's value of "provider" key
+	if p := req.Context().Value("provider"); p != nil {
+		return p.(string), nil
+	}
+
 	// if not found then return an empty string with the corresponding error
 	return "", errors.New("you must select a provider")
 }

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -247,8 +247,8 @@ func getProviderName(req *http.Request) (string, error) {
 	}
 
 	//  try to get it from the go-context's value of "provider" key
-	if p := req.Context().Value("provider"); p != nil {
-		return p.(string), nil
+	if p, ok := req.Context().Value("provider").(string); ok {
+		return p, nil
 	}
 
 	// if not found then return an empty string with the corresponding error


### PR DESCRIPTION
The function getProviderName currently support's fetching "provider' parameter only from gorilla's context. Added support to fetch the same from Go's context.