### PR TITLE
Provider name from session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: go
 sudo: false
 
 go:
-  - 1.5
-  - 1.6
   - 1.7
+  - 1.8
   - tip
 
 matrix:

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -231,6 +231,20 @@ func Logout(res http.ResponseWriter, req *http.Request) error {
 var GetProviderName = getProviderName
 
 func getProviderName(req *http.Request) (string, error) {
+
+	// get all the used providers
+	providers := goth.GetProviders()
+
+	// loop over the used providers, if we already have a valid session for any provider (ie. user is already logged-in with a provider), then return that provider name
+	for _, provider := range providers {
+		p := provider.Name()
+		session, _ := Store.Get(req, p+SessionName)
+		value := session.Values[p]
+		if _, ok := value.(string); ok {
+			return p, nil
+		}
+	}
+
 	// try to get it from the url param "provider"
 	if p := req.URL.Query().Get("provider"); p != "" {
 		return p, nil

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -246,6 +246,11 @@ func getProviderName(req *http.Request) (string, error) {
 		return p, nil
 	}
 
+	//  try to get it from the go-context's value of "provider" key
+	if p := req.Context().Value("provider"); p != nil {
+		return p.(string), nil
+	}
+
 	// if not found then return an empty string with the corresponding error
 	return "", errors.New("you must select a provider")
 }

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -247,8 +247,8 @@ func getProviderName(req *http.Request) (string, error) {
 	}
 
 	//  try to get it from the go-context's value of "provider" key
-	if p := req.Context().Value("provider"); p != nil {
-		return p.(string), nil
+	if p, ok := req.Context().Value("provider").(string); ok {
+		return p, nil
 	}
 
 	// if not found then return an empty string with the corresponding error


### PR DESCRIPTION
Currently, getProviderName function can only get Provider Name from requests. Added functionality to get Provider Name from sessions (if we already have a valid session for a provider).

Note: If user is already logged-in with a provider (say, gplus), and then user calls the url to login with another provider (say, twitter), then getProviderName will return gplus, because the user already has a saved session with gplus.