### PR TITLE
Auth endpoint for auth0 is now /authorize

### DIFF
--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -8,13 +8,14 @@ import (
 	"io"
 	"net/http"
 
+	"fmt"
+
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
-	"fmt"
 )
 
 const (
-	authEndpoint    string = "/oauth/authorize"
+	authEndpoint    string = "/authorize"
 	tokenEndpoint   string = "/oauth/token"
 	endpointProfile string = "/userinfo"
 	protocol        string = "https://"
@@ -44,11 +45,11 @@ type auth0UserResp struct {
 // create one manually.
 func New(clientKey, secret, callbackURL string, auth0Domain string, scopes ...string) *Provider {
 	p := &Provider{
-		ClientKey:           clientKey,
-		Secret:              secret,
-		CallbackURL:         callbackURL,
-		Domain:              auth0Domain,
-		providerName:        "auth0",
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		Domain:       auth0Domain,
+		providerName: "auth0",
 	}
 	p.config = newConfig(p, scopes)
 	return p

--- a/providers/auth0/auth0_test.go
+++ b/providers/auth0/auth0_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/auth0"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/jarcoal/httpmock.v1"
 )
 
 func Test_New(t *testing.T) {
@@ -34,7 +33,7 @@ func Test_BeginAuth(t *testing.T) {
 	session, err := p.BeginAuth("test_state")
 	s := session.(*auth0.Session)
 	a.NoError(err)
-	expectedAuthURL := "https://" + os.Getenv("AUTH0_DOMAIN") + "/oauth/authorize"
+	expectedAuthURL := "https://" + os.Getenv("AUTH0_DOMAIN") + "/authorize"
 	a.Contains(s.AuthURL, expectedAuthURL)
 }
 


### PR DESCRIPTION
I got an error while authenticating with the Auth0 provider and figured is the authorize url.