### PR TITLE
Feature: Add first and last name to goth user for LinkedIn provider

### DIFF
--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -135,6 +135,8 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		return err
 	}
 
+	user.FirstName = u.FirstName
+	user.LastName = u.LastName
 	user.Name = u.FirstName + " " + u.LastName
 	user.NickName = u.FirstName
 	user.Email = u.Email


### PR DESCRIPTION
This PR adds first and last name to goth user for the LinkedIn provider.  The properties exist on both structs so IMO it makes sense to pass the data along so consumers of the LinkedIn Provider don't need to manipulate the `Name` on the goth user to create first and last name fields.