### PR TITLE
Added support for Microsoft Online

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ go get github.com/markbates/goth
 
 * Amazon
 * Auth0
+* Azure AD
 * Battle.net
 * Bitbucket
 * Box
@@ -40,6 +41,7 @@ $ go get github.com/markbates/goth
 * Lastfm
 * Linkedin
 * Meetup
+* MicrosoftOnline
 * OneDrive
 * OpenID Connect (auto discovery)
 * Paypal

--- a/examples/main.go
+++ b/examples/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/markbates/goth/gothic"
 	"github.com/markbates/goth/providers/amazon"
 	"github.com/markbates/goth/providers/auth0"
+	"github.com/markbates/goth/providers/azuread"
 	"github.com/markbates/goth/providers/battlenet"
 	"github.com/markbates/goth/providers/bitbucket"
 	"github.com/markbates/goth/providers/box"
@@ -35,6 +36,7 @@ import (
 	"github.com/markbates/goth/providers/lastfm"
 	"github.com/markbates/goth/providers/linkedin"
 	"github.com/markbates/goth/providers/meetup"
+	"github.com/markbates/goth/providers/microsoftonline"
 	"github.com/markbates/goth/providers/onedrive"
 	"github.com/markbates/goth/providers/openidConnect"
 	"github.com/markbates/goth/providers/paypal"
@@ -77,6 +79,8 @@ func main() {
 		amazon.New(os.Getenv("AMAZON_KEY"), os.Getenv("AMAZON_SECRET"), "http://localhost:3000/auth/amazon/callback"),
 		yammer.New(os.Getenv("YAMMER_KEY"), os.Getenv("YAMMER_SECRET"), "http://localhost:3000/auth/yammer/callback"),
 		onedrive.New(os.Getenv("ONEDRIVE_KEY"), os.Getenv("ONEDRIVE_SECRET"), "http://localhost:3000/auth/onedrive/callback"),
+		azuread.New(os.Getenv("AZUREAD_KEY"), os.Getenv("AZUREAD_SECRET"), "http://localhost:3000/auth/azuread/callback", nil),
+		microsoftonline.New(os.Getenv("MICROSOFTONLINE_KEY"), os.Getenv("MICROSOFTONLINE_SECRET"), "http://localhost:3000/auth/microsoftonline/callback"),
 		battlenet.New(os.Getenv("BATTLENET_KEY"), os.Getenv("BATTLENET_SECRET"), "http://localhost:3000/auth/battlenet/callback"),
 		eveonline.New(os.Getenv("EVEONLINE_KEY"), os.Getenv("EVEONLINE_SECRET"), "http://localhost:3000/auth/eveonline/callback"),
 
@@ -142,6 +146,8 @@ func main() {
 	m["lastfm"] = "Last FM"
 	m["linkedin"] = "Linkedin"
 	m["onedrive"] = "Onedrive"
+	m["azuread"] = "Azure AD"
+	m["microsoftonline"] = "Microsoft Online"
 	m["battlenet"] = "Battlenet"
 	m["paypal"] = "Paypal"
 	m["twitter"] = "Twitter"

--- a/providers/azuread/azuread.go
+++ b/providers/azuread/azuread.go
@@ -183,5 +183,5 @@ func userFromReader(r io.Reader, user *goth.User) error {
 }
 
 func authorizationHeader(session *Session) (string, string) {
-	return "Authorization", fmt.Sprintf("%s %s", session.TokenType, session.AccessToken)
+	return "Authorization", fmt.Sprintf("Bearer %s", session.AccessToken)
 }

--- a/providers/azuread/azuread_test.go
+++ b/providers/azuread/azuread_test.go
@@ -51,5 +51,5 @@ func Test_SessionFromJSON(t *testing.T) {
 }
 
 func azureadProvider() *azuread.Provider {
-	return azuread.New(os.Getenv("azuread_KEY"), os.Getenv("azuread_SECRET"), "/foo", nil)
+	return azuread.New(os.Getenv("AZUREAD_KEY"), os.Getenv("AZUREAD_SECRET"), "/foo", nil)
 }

--- a/providers/azuread/session.go
+++ b/providers/azuread/session.go
@@ -14,7 +14,6 @@ type Session struct {
 	AuthURL      string
 	AccessToken  string
 	RefreshToken string
-	TokenType    string
 	ExpiresAt    time.Time
 }
 
@@ -42,11 +41,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry
-	s.TokenType = token.TokenType
 
-	if s.TokenType == "" {
-		s.TokenType = "Bearer"
-	}
 	return token.AccessToken, err
 }
 

--- a/providers/azuread/session_test.go
+++ b/providers/azuread/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &azuread.Session{}
 
 	data := s.Marshal()
-	a.Equal(`{"AuthURL":"","AccessToken":"","RefreshToken":"","TokenType":"","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
+	a.Equal(`{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/microsoftonline/microsoftonline.go
+++ b/providers/microsoftonline/microsoftonline.go
@@ -16,7 +16,7 @@ import (
 const (
 	authURL         string = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 	tokenURL        string = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-	endpointProfile string = "https://outlook.office.com/api/v2.0/me"
+	endpointProfile string = "https://graph.windows.net/v1.0/me"
 )
 
 // New creates a new microsoftonline provider, and sets up important connection details.
@@ -146,9 +146,7 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 		c.Scopes = append(c.Scopes,
 			"openid",
 			"offline_access",
-			"https://outlook.office.com/Mail.ReadWrite",
-			"https://outlook.office.com/Calendars.ReadWrite",
-			"https://outlook.office.com/Contacts.ReadWrite")
+			"user.read")
 	}
 
 	return c
@@ -156,11 +154,11 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 
 func userFromReader(r io.Reader, user *goth.User) error {
 	u := struct {
-		ID          string `json:"Id"`
-		Name        string `json:"DisplayName"`
-		Email       string `json:"EmailAddress"`
-		Alias       string `json:"Alias"`
-		MailboxGUID string `json:"MailboxGuid"`
+		ID                string `json:"id"`
+		Name              string `json:"displayName"`
+		FirstName         string `json:"givenName"`
+		LastName          string `json:"surname"`
+		UserPrincipalName string `json:"userPrincipalName"`
 	}{}
 
 	err := json.NewDecoder(r).Decode(&u)
@@ -168,10 +166,12 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		return err
 	}
 
-	user.UserID = u.ID
-	user.Email = u.Email
+	user.Email = u.UserPrincipalName
 	user.Name = u.Name
-	user.NickName = u.Alias
+	user.FirstName = u.FirstName
+	user.LastName = u.LastName
+	user.NickName = u.Name
+	user.UserID = u.ID
 
 	return nil
 }

--- a/providers/microsoftonline/microsoftonline.go
+++ b/providers/microsoftonline/microsoftonline.go
@@ -105,7 +105,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	return user, err
 }
 
-//RefreshTokenAvailable refresh token is provided by auth provider or not
+// RefreshTokenAvailable refresh token is provided by auth provider or not
+// not available for microsoft online as session size hit the limit of max cookie size
 func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }
@@ -142,7 +143,7 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 			c.Scopes = append(c.Scopes, scope)
 		}
 	} else {
-		c.Scopes = append(c.Scopes, "openid")
+		c.Scopes = append(c.Scopes, "openid", "user.read", "offline_access", "profile")
 	}
 
 	return c
@@ -171,5 +172,5 @@ func userFromReader(r io.Reader, user *goth.User) error {
 }
 
 func authorizationHeader(session *Session) (string, string) {
-	return "Authorization", fmt.Sprintf("%s %s", session.TokenType, session.AccessToken)
+	return "Authorization", fmt.Sprintf("Bearer %s", session.AccessToken)
 }

--- a/providers/microsoftonline/microsoftonline.go
+++ b/providers/microsoftonline/microsoftonline.go
@@ -143,7 +143,12 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 			c.Scopes = append(c.Scopes, scope)
 		}
 	} else {
-		c.Scopes = append(c.Scopes, "openid", "user.read", "offline_access", "profile")
+		c.Scopes = append(c.Scopes,
+			"openid",
+			"offline_access",
+			"https://outlook.office.com/Mail.ReadWrite",
+			"https://outlook.office.com/Calendars.ReadWrite",
+			"https://outlook.office.com/Contacts.ReadWrite")
 	}
 
 	return c

--- a/providers/microsoftonline/microsoftonline_test.go
+++ b/providers/microsoftonline/microsoftonline_test.go
@@ -41,7 +41,7 @@ func Test_SessionFromJSON(t *testing.T) {
 	a := assert.New(t)
 
 	provider := microsoftonlineProvider()
-	session, err := provider.UnmarshalSession(string(compressedSession()))
+	session, err := provider.UnmarshalSession(`{"AuthURL":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize","AccessToken":"1234567890","ExpiresAt":"0001-01-01T00:00:00Z"}`)
 	a.NoError(err)
 
 	s := session.(*microsoftonline.Session)

--- a/providers/microsoftonline/microsoftonline_test.go
+++ b/providers/microsoftonline/microsoftonline_test.go
@@ -1,0 +1,54 @@
+package microsoftonline_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/microsoftonline"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	provider := microsoftonlineProvider()
+
+	a.Equal(provider.ClientKey, os.Getenv("MICROSOFTONLINE_KEY"))
+	a.Equal(provider.Secret, os.Getenv("MICROSOFTONLINE_SECRET"))
+	a.Equal(provider.CallbackURL, "/foo")
+}
+
+func Test_Implements_Provider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := microsoftonlineProvider()
+	a.Implements((*goth.Provider)(nil), p)
+}
+
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	provider := microsoftonlineProvider()
+	session, err := provider.BeginAuth("test_state")
+	s := session.(*microsoftonline.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "login.microsoftonline.com/common/oauth2/v2.0/authorize")
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := microsoftonlineProvider()
+	session, err := provider.UnmarshalSession(`{"AuthURL":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize","AccessToken":"1234567890"}`)
+	a.NoError(err)
+
+	s := session.(*microsoftonline.Session)
+	a.Equal(s.AuthURL, "https://login.microsoftonline.com/common/oauth2/v2.0/authorize")
+	a.Equal(s.AccessToken, "1234567890")
+}
+
+func microsoftonlineProvider() *microsoftonline.Provider {
+	return microsoftonline.New(os.Getenv("MICROSOFTONLINE_KEY"), os.Getenv("MICROSOFTONLINE_SECRET"), "/foo")
+}

--- a/providers/microsoftonline/microsoftonline_test.go
+++ b/providers/microsoftonline/microsoftonline_test.go
@@ -41,7 +41,7 @@ func Test_SessionFromJSON(t *testing.T) {
 	a := assert.New(t)
 
 	provider := microsoftonlineProvider()
-	session, err := provider.UnmarshalSession(`{"AuthURL":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize","AccessToken":"1234567890"}`)
+	session, err := provider.UnmarshalSession(string(compressedSession()))
 	a.NoError(err)
 
 	s := session.(*microsoftonline.Session)

--- a/providers/microsoftonline/session.go
+++ b/providers/microsoftonline/session.go
@@ -1,11 +1,8 @@
 package microsoftonline
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -49,20 +46,8 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 
 // Marshal the session into a string
 func (s Session) Marshal() string {
-	data, _ := json.Marshal(s)
-
-	var b bytes.Buffer
-	gz := gzip.NewWriter(&b)
-	if _, err := gz.Write([]byte(data)); err != nil {
-		panic(err)
-	}
-	if err := gz.Flush(); err != nil {
-		panic(err)
-	}
-	if err := gz.Close(); err != nil {
-		panic(err)
-	}
-	return b.String()
+	b, _ := json.Marshal(s)
+	return string(b)
 }
 
 func (s Session) String() string {
@@ -72,17 +57,6 @@ func (s Session) String() string {
 // UnmarshalSession wil unmarshal a JSON string into a session.
 func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 	session := &Session{}
-
-	rdata := strings.NewReader(data)
-	r, err := gzip.NewReader(rdata)
-	if err != nil {
-		return session, err
-	}
-	s, err := ioutil.ReadAll(r)
-	if err != nil {
-		return session, err
-	}
-
-	err = json.NewDecoder(bytes.NewReader(s)).Decode(session)
+	err := json.NewDecoder(strings.NewReader(data)).Decode(session)
 	return session, err
 }

--- a/providers/microsoftonline/session.go
+++ b/providers/microsoftonline/session.go
@@ -10,12 +10,11 @@ import (
 )
 
 // Session is the implementation of `goth.Session` for accessing microsoftonline.
+// Refresh token not available for microsoft online: session size hit the limit of max cookie size
 type Session struct {
-	AuthURL      string
-	AccessToken  string
-	RefreshToken string
-	TokenType    string
-	ExpiresAt    time.Time
+	AuthURL     string
+	AccessToken string
+	ExpiresAt   time.Time
 }
 
 // GetAuthURL will return the URL set by calling the `BeginAuth` function on the Facebook provider.
@@ -40,13 +39,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 
 	s.AccessToken = token.AccessToken
-	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry
-	s.TokenType = token.TokenType
-
-	if s.TokenType == "" {
-		s.TokenType = "Bearer"
-	}
 
 	return token.AccessToken, err
 }

--- a/providers/microsoftonline/session.go
+++ b/providers/microsoftonline/session.go
@@ -1,4 +1,4 @@
-package azuread
+package microsoftonline
 
 import (
 	"encoding/json"
@@ -9,7 +9,7 @@ import (
 	"github.com/markbates/goth"
 )
 
-// Session is the implementation of `goth.Session` for accessing AzureAD.
+// Session is the implementation of `goth.Session` for accessing microsoftonline.
 type Session struct {
 	AuthURL      string
 	AccessToken  string
@@ -47,6 +47,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if s.TokenType == "" {
 		s.TokenType = "Bearer"
 	}
+
 	return token.AccessToken, err
 }
 

--- a/providers/microsoftonline/session_test.go
+++ b/providers/microsoftonline/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &microsoftonline.Session{}
 
 	data := s.Marshal()
-	a.Equal(`{"AuthURL":"","AccessToken":"","RefreshToken":"","TokenType":"","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
+	a.Equal(`{"AuthURL":"","AccessToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/microsoftonline/session_test.go
+++ b/providers/microsoftonline/session_test.go
@@ -1,29 +1,12 @@
 package microsoftonline_test
 
 import (
-	"fmt"
-	"runtime"
 	"testing"
 
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/microsoftonline"
 	"github.com/stretchr/testify/assert"
 )
-
-// compressed session of: Session{AuthURL:"https://login.microsoftonline.com/common/oauth2/v2.0/authorize",AccessToken: "1234567890"}
-var compressedSession18 = []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 28, 198, 191, 10, 194, 48, 16, 7, 224, 119, 249, 205, 181, 119, 173, 255, 179, 117, 112, 115, 146, 186, 184, 73, 136, 38, 216, 228, 74, 114, 21, 81, 124, 119, 177, 240, 13, 223, 7, 221, 164, 254, 124, 58, 194, 192, 171, 142, 197, 16, 13, 114, 15, 169, 142, 193, 102, 41, 114, 83, 73, 67, 72, 174, 182, 18, 201, 74, 140, 146, 72, 174, 147, 250, 150, 158, 109, 205, 244, 175, 228, 240, 118, 168, 208, 89, 235, 74, 233, 229, 225, 18, 12, 154, 118, 185, 90, 111, 182, 187, 61, 163, 194, 225, 53, 134, 236, 74, 167, 48, 96, 230, 102, 49, 235, 153, 205, 236, 130, 239, 15, 0, 0, 255, 255, 1, 0, 0, 255, 255, 123, 236, 131, 18, 138, 0, 0, 0}
-var compressedSession17 = []byte{31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 28, 198, 191, 10, 194, 48, 16, 7, 224, 119, 249, 205, 181, 119, 173, 255, 179, 117, 112, 115, 146, 186, 184, 73, 136, 38, 216, 228, 74, 114, 21, 81, 124, 119, 177, 240, 13, 223, 7, 221, 164, 254, 124, 58, 194, 192, 171, 142, 197, 16, 13, 114, 15, 169, 142, 193, 102, 41, 114, 83, 73, 67, 72, 174, 182, 18, 201, 74, 140, 146, 72, 174, 147, 250, 150, 158, 109, 205, 244, 175, 228, 240, 118, 168, 208, 89, 235, 74, 233, 229, 225, 18, 12, 154, 118, 185, 90, 111, 182, 187, 61, 163, 194, 225, 53, 134, 236, 74, 167, 48, 96, 230, 102, 49, 235, 153, 205, 236, 130, 239, 15, 0, 0, 255, 255, 1, 0, 0, 255, 255, 123, 236, 131, 18, 138, 0, 0, 0}
-
-// retrieves session based on runtime version as gziped values differs in some bytes between versions
-func compressedSession() []byte {
-	var minor int
-	fmt.Sscanf(runtime.Version(), "go1.%d", &minor)
-
-	if minor <= 7 {
-		return compressedSession17
-	}
-	return compressedSession18
-}
 
 func Test_Implements_Session(t *testing.T) {
 	t.Parallel()
@@ -56,7 +39,7 @@ func Test_ToJSON(t *testing.T) {
 	}
 
 	data := s.Marshal()
-	a.Equal(compressedSession(), []byte(data))
+	a.Equal(`{"AuthURL":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize","AccessToken":"1234567890","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/microsoftonline/session_test.go
+++ b/providers/microsoftonline/session_test.go
@@ -1,17 +1,17 @@
-package azuread_test
+package microsoftonline_test
 
 import (
 	"testing"
 
 	"github.com/markbates/goth"
-	"github.com/markbates/goth/providers/azuread"
+	"github.com/markbates/goth/providers/microsoftonline"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_Implements_Session(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &azuread.Session{}
+	s := &microsoftonline.Session{}
 
 	a.Implements((*goth.Session)(nil), s)
 }
@@ -19,7 +19,7 @@ func Test_Implements_Session(t *testing.T) {
 func Test_GetAuthURL(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &azuread.Session{}
+	s := &microsoftonline.Session{}
 
 	_, err := s.GetAuthURL()
 	a.Error(err)
@@ -33,7 +33,7 @@ func Test_GetAuthURL(t *testing.T) {
 func Test_ToJSON(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &azuread.Session{}
+	s := &microsoftonline.Session{}
 
 	data := s.Marshal()
 	a.Equal(`{"AuthURL":"","AccessToken":"","RefreshToken":"","TokenType":"","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
@@ -42,7 +42,7 @@ func Test_ToJSON(t *testing.T) {
 func Test_String(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &azuread.Session{}
+	s := &microsoftonline.Session{}
 
 	a.Equal(s.String(), s.Marshal())
 }

--- a/providers/microsoftonline/session_test.go
+++ b/providers/microsoftonline/session_test.go
@@ -1,12 +1,29 @@
 package microsoftonline_test
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/microsoftonline"
 	"github.com/stretchr/testify/assert"
 )
+
+// compressed session of: Session{AuthURL:"https://login.microsoftonline.com/common/oauth2/v2.0/authorize",AccessToken: "1234567890"}
+var compressedSession18 = []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 28, 198, 191, 10, 194, 48, 16, 7, 224, 119, 249, 205, 181, 119, 173, 255, 179, 117, 112, 115, 146, 186, 184, 73, 136, 38, 216, 228, 74, 114, 21, 81, 124, 119, 177, 240, 13, 223, 7, 221, 164, 254, 124, 58, 194, 192, 171, 142, 197, 16, 13, 114, 15, 169, 142, 193, 102, 41, 114, 83, 73, 67, 72, 174, 182, 18, 201, 74, 140, 146, 72, 174, 147, 250, 150, 158, 109, 205, 244, 175, 228, 240, 118, 168, 208, 89, 235, 74, 233, 229, 225, 18, 12, 154, 118, 185, 90, 111, 182, 187, 61, 163, 194, 225, 53, 134, 236, 74, 167, 48, 96, 230, 102, 49, 235, 153, 205, 236, 130, 239, 15, 0, 0, 255, 255, 1, 0, 0, 255, 255, 123, 236, 131, 18, 138, 0, 0, 0}
+var compressedSession17 = []byte{31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 28, 198, 191, 10, 194, 48, 16, 7, 224, 119, 249, 205, 181, 119, 173, 255, 179, 117, 112, 115, 146, 186, 184, 73, 136, 38, 216, 228, 74, 114, 21, 81, 124, 119, 177, 240, 13, 223, 7, 221, 164, 254, 124, 58, 194, 192, 171, 142, 197, 16, 13, 114, 15, 169, 142, 193, 102, 41, 114, 83, 73, 67, 72, 174, 182, 18, 201, 74, 140, 146, 72, 174, 147, 250, 150, 158, 109, 205, 244, 175, 228, 240, 118, 168, 208, 89, 235, 74, 233, 229, 225, 18, 12, 154, 118, 185, 90, 111, 182, 187, 61, 163, 194, 225, 53, 134, 236, 74, 167, 48, 96, 230, 102, 49, 235, 153, 205, 236, 130, 239, 15, 0, 0, 255, 255, 1, 0, 0, 255, 255, 123, 236, 131, 18, 138, 0, 0, 0}
+
+// retrieves session based on runtime version as gziped values differs in some bytes between versions
+func compressedSession() []byte {
+	var minor int
+	fmt.Sscanf(runtime.Version(), "go1.%d", &minor)
+
+	if minor <= 7 {
+		return compressedSession17
+	}
+	return compressedSession18
+}
 
 func Test_Implements_Session(t *testing.T) {
 	t.Parallel()
@@ -33,16 +50,22 @@ func Test_GetAuthURL(t *testing.T) {
 func Test_ToJSON(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &microsoftonline.Session{}
+	s := &microsoftonline.Session{
+		AuthURL:     "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+		AccessToken: "1234567890",
+	}
 
 	data := s.Marshal()
-	a.Equal(`{"AuthURL":"","AccessToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`, data)
+	a.Equal(compressedSession(), []byte(data))
 }
 
 func Test_String(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
-	s := &microsoftonline.Session{}
+	s := &microsoftonline.Session{
+		AuthURL:     "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+		AccessToken: "1234567890",
+	}
 
 	a.Equal(s.String(), s.Marshal())
 }


### PR DESCRIPTION
- Added support for V2 of Microsoft Online OAuth2 API which can be used for Microsoft personal accounts.
- Small fixes in AzureAD provider
- Updated example suit

To test, application needs to be registered in [Application Registration Portal](https://apps.dev.microsoft.com/)
