### PR TITLE
Fix #192 (with the same fix originally in #182)

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -147,7 +147,6 @@ as either "provider" or ":provider".
 See https://github.com/markbates/goth/examples/main.go to see this in action.
 */
 var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.User, error) {
-	defer Logout(res, req)
 	if !keySet && defaultStore == Store {
 		fmt.Println("goth/gothic: no SESSION_SECRET environment variable is set. The default cookie store is not available and any calls will fail. Ignore this warning if you are using a different store.")
 	}
@@ -167,6 +166,8 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 		return goth.User{}, err
 	}
 
+	// Only logout to delete the session once we know we have one.
+	defer Logout(res, req)
 	sess, err := provider.UnmarshalSession(value)
 	if err != nil {
 		return goth.User{}, err


### PR DESCRIPTION
We were deleting the session even if one didn't exist. This seems to not work properly with the cookie session store due to multiple calls to Set-Cookie for the same cookie.