### PR TITLE
Feature: Slack Provider - Add First and Last Name 

### DIFF
--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -164,6 +164,8 @@ func userFromReader(r io.Reader, user *goth.User) error {
 				Email     string `json:"email"`
 				Name      string `json:"real_name"`
 				AvatarURL string `json:"image_32"`
+				FirstName string `json:"first_name"`
+				LastName string `json:"last_name"`
 			} `json:"profile"`
 		} `json:"user"`
 	}{}
@@ -176,6 +178,8 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.NickName = u.User.NickName
 	user.UserID = u.User.ID
 	user.AvatarURL = u.User.Profile.AvatarURL
+	user.FirstName = u.User.Profile.FirstName
+	user.LastName = u.User.Profile.LastName
 	return nil
 }
 


### PR DESCRIPTION
This PR adds first and last name to the `goth.User` as extracted from slack.  While they are not [guaranteed](https://api.slack.com/methods/users.info) to be present, it's worth trying.