### PR TITLE
Export Provider.OpenIDConfig

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -54,7 +54,7 @@ type Provider struct {
 	CallbackURL  string
 	HTTPClient   *http.Client
 	config       *oauth2.Config
-	openIDConfig *OpenIDConfig
+	OpenIDConfig *OpenIDConfig
 	providerName string
 
 	UserIdClaims    []string


### PR DESCRIPTION
I'm currently trying to use Goth with an identity provider that uses the OpenID Connect authorization code flow. This flow requires calling the token endpoint. Goth currently extracts the token endpoint URL from auto-discovery, but provides no helpers for calling that endpoint, nor does make the TokenEndpoint field accessible. That means I either need to do my own auto-discovery again, or hardcode the token endpoint URL.