### PR TITLE
When storing new value in session use `New`

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -286,7 +286,7 @@ func getProviderName(req *http.Request) (string, error) {
 
 // StoreInSession stores a specified key/value pair in the session.
 func StoreInSession(key string, value string, req *http.Request, res http.ResponseWriter) error {
-	session, _ := Store.Get(req, SessionName)
+	session, _ := Store.New(req, SessionName)
 
 	if err := updateSessionValue(session, key, value); err != nil {
 		return err


### PR DESCRIPTION
If using `Get` after `Logout` has set `MaxAge` to `-1` it will stay so and value won't be saved to session. Fixes #192