### PR TITLE
providers/instagram: use full_name on user.Name

### DIFF
--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -130,7 +130,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		return err
 	}
 	user.UserID = u.Data.ID
-	user.Name = u.Data.UserName
+	user.Name = u.Data.FullName
 	user.NickName = u.Data.UserName
 	user.AvatarURL = u.Data.ProfilePicture
 	user.Description = u.Data.Bio


### PR DESCRIPTION
On the Instagram provider, instead of using `username` for both `user.Name` and `user.NickName`, use `full_name` for the `user.Name`.