### PR TITLE
[deps] Add go.mod for versioned Go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/markbates/goth
+
+require (
+	github.com/gorilla/mux v1.6.2
+	github.com/gorilla/pat v0.0.0-20180118222023-199c85a7f6d1
+	github.com/gorilla/sessions v1.1.1
+	github.com/markbates/going v1.0.0
+	github.com/mrjones/oauth v0.0.0-20180629183705-f4e24b6d100c
+	golang.org/x/net v0.0.0-20180706051357-32a936f46389
+	golang.org/x/oauth2 v0.0.0-20180620175406-ef147856a6dd
+)


### PR DESCRIPTION
Adds a go.mod file generated by the [vgo](https://github.com/golang/vgo) tool by running `vgo generate ./...`.