### PR TITLE
Discord avatar URL update

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -164,7 +164,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 
 	user.Name = u.Name
 	user.Email = u.Email
-	user.AvatarURL = "https://discordapp.com/api/users/" + u.ID + "/avatars/" + u.AvatarID + ".jpg"
+	user.AvatarURL = "https://media.discordapp.net/avatars/" + u.ID + "/" + u.AvatarID + ".jpg"
 	user.UserID = u.ID
 
 	return nil


### PR DESCRIPTION
The old solution still worked but only for `.jpg` extension, it redirected to the new avatar URL discord uses but it doesn't redirect for if you replace `.jpg` with `.png`.
__JPG__
`https://discordapp.com/api/users/ID/avatars/AVATAR.jpg` => `https://media.discordapp.net/avatars/ID/AVATAR.jpg`
__PNG__
`https://discordapp.com/api/users/ID/avatars/AVATAR.png` => `404`

**TL:DR**
The current avatar URL is outdated and needs to be updated.