### PR TITLE
Migrate x/net/context to standard lib context

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -1,10 +1,10 @@
 package goth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -4,15 +4,15 @@ package cloudfoundry
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
-	"fmt"
 	"github.com/markbates/goth"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/providers/cloudfoundry/session.go
+++ b/providers/cloudfoundry/session.go
@@ -1,13 +1,13 @@
 package cloudfoundry
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
 	"time"
 
 	"github.com/markbates/goth"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 


### PR DESCRIPTION
Since Go 1.7 this package is available in the standard library under the name context.  https://golang.org/pkg/context.

Looking at the travis CI, I found that you support only Go1.7+ so this will permit to use the standard definition of context.