### PR TITLE
Do not use user_ids field in VK provider

### DIFF
--- a/providers/vk/session.go
+++ b/providers/vk/session.go
@@ -14,7 +14,6 @@ type Session struct {
 	AuthURL     string
 	AccessToken string
 	ExpiresAt   time.Time
-	userID      int64
 	email       string
 }
 
@@ -49,15 +48,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", errors.New("Cannot fetch user email")
 	}
 
-	userID, ok := token.Extra("user_id").(float64)
-	if !ok {
-		return "", errors.New("Cannot fetch user ID")
-	}
-
 	s.AccessToken = token.AccessToken
 	s.ExpiresAt = token.Expiry
 	s.email = email
-	s.userID = int64(userID)
 	return s.AccessToken, err
 }
 

--- a/providers/vk/vk.go
+++ b/providers/vk/vk.go
@@ -87,7 +87,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 
 	fields := "photo_200,nickname"
-	requestURL := fmt.Sprintf("%s?user_ids=%d&fields=%s&access_token=%s&v=%s", endpointUser, sess.userID, fields, sess.AccessToken, apiVersion)
+	requestURL := fmt.Sprintf("%s?fields=%s&access_token=%s&v=%s", endpointUser, fields, sess.AccessToken, apiVersion)
 	response, err := p.Client().Get(requestURL)
 	if err != nil {
 		return user, err


### PR DESCRIPTION
Because user_ids is an optional field and it does not allow
to use VK provider with already known access_token