### PR TITLE
Fix provider deduction from existing sessions so that an argument is not needed on the authentication landing page.

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -245,19 +245,6 @@ var GetProviderName = getProviderName
 
 func getProviderName(req *http.Request) (string, error) {
 
-	// get all the used providers
-	providers := goth.GetProviders()
-
-	// loop over the used providers, if we already have a valid session for any provider (ie. user is already logged-in with a provider), then return that provider name
-	for _, provider := range providers {
-		p := provider.Name()
-		session, _ := Store.Get(req, p+SessionName)
-		value := session.Values[p]
-		if _, ok := value.(string); ok {
-			return p, nil
-		}
-	}
-
 	// try to get it from the url param "provider"
 	if p := req.URL.Query().Get("provider"); p != "" {
 		return p, nil
@@ -276,6 +263,17 @@ func getProviderName(req *http.Request) (string, error) {
 	//  try to get it from the go-context's value of "provider" key
 	if p, ok := req.Context().Value("provider").(string); ok {
 		return p, nil
+	}
+
+	// As a fallback, loop over the used providers, if we already have a valid session for any provider (ie. user has already begun authentication with a provider), then return that provider name
+	providers := goth.GetProviders()
+	session, _ := Store.Get(req, SessionName)
+	for _, provider := range providers {
+		p := provider.Name()
+		value := session.Values[p]
+		if _, ok := value.(string); ok {
+			return p, nil
+		}
 	}
 
 	// if not found then return an empty string with the corresponding error


### PR DESCRIPTION
This has been broken since https://github.com/markbates/goth/commit/78433fec1a8fed110af91e79c94be2d835afe637.

Also moving the deduction code to be a fallback: if a provider is explicitly
specified it should not be overridden by the existing session. I believe
this is why the Logout() problems with multiple providers existed in the
first place. If deduction wins over explicit parameters, then once you
wrongly click one provider, the cookie will force you to use that
authentication mechanism even if you've navigated to a URL that
explicitly states another provider's name.

Fixed the test harness to check session key names (this was a bug in the
test harness) and added a test to verify that this change works.