### PR TITLE
Export a non-collidable context key for setting provider in context

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -35,6 +35,10 @@ var defaultStore sessions.Store
 
 var keySet = false
 
+type key int
+// ProviderParamKey can be used as a key in context when passing in a provider
+const ProviderParamKey key = iota
+
 func init() {
 	key := []byte(os.Getenv("SESSION_SECRET"))
 	keySet = len(key) != 0
@@ -262,6 +266,11 @@ func getProviderName(req *http.Request) (string, error) {
 
 	//  try to get it from the go-context's value of "provider" key
 	if p, ok := req.Context().Value("provider").(string); ok {
+		return p, nil
+	}
+
+	// try to get it from the go-context's value of providerContextKey key
+	if p, ok := req.Context().Value(ProviderParamKey).(string); ok {
 		return p, nil
 	}
 


### PR DESCRIPTION
This pull request add an exported [key constant](https://blog.golang.org/context#TOC_3.2.) that can be used when adding the `provider` to a context for `gothic`. Using this exported key prevents the go-lint error `Should not use basic type string as key in context.WithValue`.

```golang
provider := "github"
ctx := context.WithValue(req.Context(), gothic.ProviderParamKey, provider)
req = req.WithContext(ctx)
```

Closes #238 