### PR TITLE
Add email and is_private_email to Apple id_token

### DIFF
--- a/providers/apple/apple.go
+++ b/providers/apple/apple.go
@@ -117,6 +117,8 @@ func (Provider) UnmarshalSession(data string) (goth.Session, error) {
 // as the only identifying attribute.
 // A full name and email can be obtained from the form post response
 // to the redirect page following authentication, if the name are email scopes are requested.
+// Additionally, if the response type is form_post and the email scope is requested, the email
+// will be encoded into the ID token in the email claim.
 func (p Provider) FetchUser(session goth.Session) (goth.User, error) {
 	s := session.(*Session)
 	if s.AccessToken == "" {
@@ -125,6 +127,7 @@ func (p Provider) FetchUser(session goth.Session) (goth.User, error) {
 	return goth.User{
 		Provider:     p.Name(),
 		UserID:       s.ID.Sub,
+		Email:        s.ID.Email,
 		AccessToken:  s.AccessToken,
 		RefreshToken: s.RefreshToken,
 		ExpiresAt:    s.ExpiresAt,

--- a/providers/apple/session.go
+++ b/providers/apple/session.go
@@ -20,7 +20,9 @@ const (
 )
 
 type ID struct {
-	Sub string `json:"sub"`
+	Sub            string `json:"sub"`
+	Email          string `json:"email"`
+	IsPrivateEmail bool   `json:"is_private_email"`
 }
 
 type Session struct {
@@ -47,6 +49,8 @@ type IDTokenClaims struct {
 	jwt.StandardClaims
 	AccessTokenHash string `json:"at_hash"`
 	AuthTime        int    `json:"auth_time"`
+	Email           string `json:"email"`
+	IsPrivateEmail  bool   `json:"is_private_email,string"`
 }
 
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
@@ -112,7 +116,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 			return "", err
 		}
 		s.ID = ID{
-			Sub: idToken.Claims.(*IDTokenClaims).Subject,
+			Sub:            idToken.Claims.(*IDTokenClaims).Subject,
+			Email:          idToken.Claims.(*IDTokenClaims).Email,
+			IsPrivateEmail: idToken.Claims.(*IDTokenClaims).IsPrivateEmail,
 		}
 	}
 

--- a/providers/apple/session_test.go
+++ b/providers/apple/session_test.go
@@ -35,7 +35,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z","sub":""}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z","sub":"","email":"","is_private_email":false}`)
 }
 
 func Test_String(t *testing.T) {


### PR DESCRIPTION
Apple now includes an `email` claim within the decoded `id_token`. Since that value is encoded within the token, it is safest to trust and use that value instead of the email included in the form post response to the auth callback. This PR adds support for pulling the email claim from the token and storing it in the `ID` struct on the session. Additionally, if the email is an anonymous email created to use Apple's private email relay service, there will be a `is_private_email` claim with a value of `true`. This PR also adds that value into the ID struct on the session.

While the documentation around Sign In With Apple is unfortunately very lacking in details, I have been able to piece together the following information from guides and official apple responses on support forums:
* You can only get access to the email if you request it using the `email` scope.
* Apple will only supply the email if you set `response_mode=form_post` (done for you by the Apple provider when you request email and/or name scopes
* Keep in mind this means you need to edit your code to also accept POST requests to the callback URL, and modify your Gothic logic to use the post body (instead of URL query params) for state verification in `validateState` and also in the call to `sess.Authorize` in `CompleteUserAuth`.
* The email and/or name will be available in the initial POST callback after signing in with Apple. These values cannot necessarily be trusted from tampering here.
* The email (but not the name??!) will also be included in the `email` claim of the decoded `id_token`.
* Whether looking at the POST form response or the decoded id_token, the email is only included the very first time the user authenticates your app using Sign In With Apple. Future login attempts will not deliver the email (or name) to you.