### PR TITLE
Helper method for setting provider in http context

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -10,6 +10,7 @@ package gothic
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -36,6 +37,7 @@ var defaultStore sessions.Store
 var keySet = false
 
 type key int
+
 // ProviderParamKey can be used as a key in context when passing in a provider
 const ProviderParamKey key = iota
 
@@ -287,6 +289,11 @@ func getProviderName(req *http.Request) (string, error) {
 
 	// if not found then return an empty string with the corresponding error
 	return "", errors.New("you must select a provider")
+}
+
+// GetContextWithProvider returns a new request context containing the provider
+func GetContextWithProvider(req *http.Request, provider string) *http.Request {
+	return req.WithContext(context.WithValue(req.Context(), ProviderParamKey, provider))
 }
 
 // StoreInSession stores a specified key/value pair in the session.

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -166,6 +166,28 @@ func Test_CompleteUserAuthWithSessionDeducedProvider(t *testing.T) {
 	a.Equal(user.Email, "homer@example.com")
 }
 
+func Test_CompleteUserAuthWithContextParamProvider(t *testing.T) {
+	a := assert.New(t)
+
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/auth/callback", nil)
+	a.NoError(err)
+
+	req = GetContextWithProvider(req, "faux")
+
+	sess := faux.Session{Name: "Homer Simpson", Email: "homer@example.com"}
+	session, _ := Store.Get(req, SessionName)
+	session.Values["faux"] = gzipString(sess.Marshal())
+	err = session.Save(req, res)
+	a.NoError(err)
+
+	user, err := CompleteUserAuth(res, req)
+	a.NoError(err)
+
+	a.Equal(user.Name, "Homer Simpson")
+	a.Equal(user.Email, "homer@example.com")
+}
+
 func Test_Logout(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
This pull request adds a `GetContextWithProvider` method to `gothic/gothic.go` to reduce the boilerplate required to set a `provider` in the http context.

I have included a test but I am not sure it is useful.

https://github.com/markbates/goth/pull/301#pullrequestreview-342869518