### PR TITLE
Added custom auth code options for google

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -32,13 +32,13 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Google.
 type Provider struct {
-	ClientKey    string
-	Secret       string
-	CallbackURL  string
-	HTTPClient   *http.Client
-	config       *oauth2.Config
-	prompt       oauth2.AuthCodeOption
-	providerName string
+	ClientKey       string
+	Secret          string
+	CallbackURL     string
+	HTTPClient      *http.Client
+	config          *oauth2.Config
+	providerName    string
+	authCodeOptions []oauth2.AuthCodeOption
 }
 
 // Name is the name used to retrieve this provider later.
@@ -61,11 +61,8 @@ func (p *Provider) Debug(debug bool) {}
 
 // BeginAuth asks Google for an authentication endpoint.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
-	var opts []oauth2.AuthCodeOption
-	if p.prompt != nil {
-		opts = append(opts, p.prompt)
-	}
-	url := p.config.AuthCodeURL(state, opts...)
+
+	url := p.config.AuthCodeURL(state, p.authCodeOptions...)
 	session := &Session{
 		AuthURL: url,
 	}
@@ -176,5 +173,12 @@ func (p *Provider) SetPrompt(prompt ...string) {
 	if len(prompt) == 0 {
 		return
 	}
-	p.prompt = oauth2.SetAuthURLParam("prompt", strings.Join(prompt, " "))
+	p.authCodeOptions = append(p.authCodeOptions, oauth2.SetAuthURLParam("prompt", strings.Join(prompt, " ")))
+}
+
+// SetAuthCodeOptions sets the auth code options to be used in calls to
+// oauth2.Config.AuthCodeURL.
+// See https://godoc.org/golang.org/x/oauth2#Config.AuthCodeURL
+func (p *Provider) SetAuthCodeOptions(opts ...oauth2.AuthCodeOption) {
+	p.authCodeOptions = opts
 }

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"golang.org/x/oauth2"
+
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/providers/google"
 	"github.com/stretchr/testify/assert"
@@ -51,6 +53,22 @@ func Test_BeginAuthWithPrompt(t *testing.T) {
 	a.Contains(s.AuthURL, "state=test_state")
 	a.Contains(s.AuthURL, "scope=email")
 	a.Contains(s.AuthURL, "prompt=test+prompts")
+}
+
+func Test_BeginAuthWithOfflineAccess(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := googleProvider()
+	provider.SetAuthCodeOptions(oauth2.AccessTypeOffline)
+	session, err := provider.BeginAuth("test_state")
+	s := session.(*google.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "accounts.google.com/o/oauth2/auth")
+	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("GOOGLE_KEY")))
+	a.Contains(s.AuthURL, "state=test_state")
+	a.Contains(s.AuthURL, "scope=email")
+	a.Contains(s.AuthURL, "access_type=offline")
 }
 
 func Test_Implements_Provider(t *testing.T) {


### PR DESCRIPTION
Might just be missing something, but couldn't find a way currently to set access_type=offline to get a refresh token for this provider