### PR TITLE
Return an error for no GitHub email

### DIFF
--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -202,8 +202,7 @@ func getPrivateMail(p *Provider, sess *Session) (email string, err error) {
 			return v.Email, nil
 		}
 	}
-	// can't get primary email - shouldn't be possible
-	return
+	return email, fmt.Errorf("The user does not have a verified, primary email address on GitHub")
 }
 
 func newConfig(provider *Provider, authURL, tokenURL string, scopes []string) *oauth2.Config {


### PR DESCRIPTION
It is possible for a GitHub user not to have a verified primary email address, at least this has happened in practice.

I believe GitHub can deem an address as "undeliverable", which means it loses its verified status:
https://github.community/t5/How-to-use-Git-and-GitHub/How-often-need-I-verify-my-email/td-p/7177