### PR TITLE
Added "profile" in array of scopes in file google.go.

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -32,13 +32,13 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Google.
 type Provider struct {
-	ClientKey    string
-	Secret       string
-	CallbackURL  string
-	HTTPClient   *http.Client
-	config       *oauth2.Config
-	prompt       oauth2.AuthCodeOption
-	providerName string
+	ClientKey       string
+	Secret          string
+	CallbackURL     string
+	HTTPClient      *http.Client
+	config          *oauth2.Config
+	authCodeOptions []oauth2.AuthCodeOption
+	providerName    string
 }
 
 // Name is the name used to retrieve this provider later.
@@ -61,11 +61,7 @@ func (p *Provider) Debug(debug bool) {}
 
 // BeginAuth asks Google for an authentication endpoint.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
-	var opts []oauth2.AuthCodeOption
-	if p.prompt != nil {
-		opts = append(opts, p.prompt)
-	}
-	url := p.config.AuthCodeURL(state, opts...)
+	url := p.config.AuthCodeURL(state, p.authCodeOptions...)
 	session := &Session{
 		AuthURL: url,
 	}
@@ -112,9 +108,6 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, err
 	}
 
-	// fmt.Println("Raw response from google")
-	// fmt.Println(string(responseBytes))
-	// fmt.Println("Raw response from google")
 	var u googleUser
 	if err := json.Unmarshal(responseBytes, &u); err != nil {
 		return user, err
@@ -150,18 +143,18 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 			c.Scopes = append(c.Scopes, scope)
 		}
 	} else {
-		// Default scopes of google oauth2.0 api.
+		// Default scopes of google api oauth2.0 .
 		c.Scopes = []string{"email", "profile"}
 	}
 	return c
 }
 
-//RefreshTokenAvailable refresh token is provided by auth provider or not
+// RefreshTokenAvailable refresh token is provided by auth provider or not
 func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//RefreshToken get new access token based on the refresh token
+// RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(goth.ContextForClient(p.Client()), token)
@@ -180,5 +173,15 @@ func (p *Provider) SetPrompt(prompt ...string) {
 	if len(prompt) == 0 {
 		return
 	}
-	p.prompt = oauth2.SetAuthURLParam("prompt", strings.Join(prompt, " "))
+	p.authCodeOptions = append(p.authCodeOptions, oauth2.SetAuthURLParam("prompt", strings.Join(prompt, " ")))
+}
+
+// SetHostedDomain sets the hd parameter for google OAuth call.
+// Use this to force user to pick user from specific hosted domain.
+// See https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param
+func (p *Provider) SetHostedDomain(hd string) {
+	if hd == "" {
+		return
+	}
+	p.authCodeOptions = append(p.authCodeOptions, oauth2.SetAuthURLParam("hd", hd))
 }


### PR DESCRIPTION
email and profile are default scopes of google api oauth2.0.

When a developer does not provide scope values then by default it can now fetch both email and basic profile information from google api oauth2.0.

Very handy for beginners.