### PR TITLE
Capture state when coming from a POST request

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -227,6 +227,9 @@ func validateState(req *http.Request, sess goth.Session) error {
 	}
 
 	reqState := GetState(req)
+	if req.Method == http.MethodPost && reqState == "" {
+		reqState = req.FormValue("state")
+	}
 
 	originalState := authURL.Query().Get("state")
 	if originalState != "" && (originalState != reqState) {


### PR DESCRIPTION
Sign-in with Apple sends the `code` and `state` values after the authentication exchange has been successful using a POST request. The current code is not expecting it and returns a 405 response with the message `state token mismatch`.

This fixed it for me, so I'm putting it under consideration to be merged in the code. If this is the wrong approach, I would appreciate any input you can provide so I can make the proper changes in my code.