### PR TITLE
Replace the usage of deprecated Materialize() for Raw()

### DIFF
--- a/providers/apple/session.go
+++ b/providers/apple/session.go
@@ -112,7 +112,8 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 					break
 				}
 			}
-			pubKeyIface, _ := selectedKey.Materialize()
+			var pubKeyIface interface{}
+			_ = selectedKey.Raw(&pubKeyIface)
 			pubKey, ok := pubKeyIface.(*rsa.PublicKey)
 			if !ok {
 				return nil, fmt.Errorf(`expected RSA public key from %s`, idTokenVerificationKeyEndpoint)


### PR DESCRIPTION
The Apple provider uses `github.com/lestrrat-go/jwx/jwk` as a dependency, which deprecated the `Materialize()` method since May this year: https://github.com/lestrrat-go/jwx/blob/3d8cae88e8782b73d109e2cf66603b76826dd079/Changes#L68

The default configuration for Go Modules uses the most recent version of the jwx package, causing the Apple provider to throw the following error during compilation:
```
session.go:117:33: selectedKey.Materialize undefined (type jwk.Key has no field or method Materialize)
```

The current PR fixed it for me, I'm putting it under consideration in case is the right approach and may be helpful to the community.