### PR TITLE
Update Apple provider to use %20 space encoding instead of +

### DIFF
--- a/providers/apple/apple.go
+++ b/providers/apple/apple.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -101,8 +102,16 @@ func (p Provider) BeginAuth(state string) (goth.Session, error) {
 	if p.formPostResponseMode {
 		opts = append(opts, oauth2.SetAuthURLParam("response_mode", "form_post"))
 	}
+	authURL := p.config.AuthCodeURL(state, opts...)
+	if authURL != "" {
+		if u, err := url.Parse(authURL); err == nil {
+			// Apple requires spaces to be encoded as %20 instead of +
+			u.RawQuery = strings.ReplaceAll(u.RawQuery, "+", "%20")
+			authURL = u.String()
+		}
+	}
 	return &Session{
-		AuthURL: p.config.AuthCodeURL(state, opts...),
+		AuthURL: authURL,
 	}, nil
 }
 

--- a/providers/apple/apple_test.go
+++ b/providers/apple/apple_test.go
@@ -99,3 +99,21 @@ func TestAuthorize(t *testing.T) {
 		a.Fail(errStr)
 	}
 }
+
+func TestBeginAuth(t *testing.T) {
+	a := assert.New(t)
+
+	client := http.DefaultClient
+	p := New(
+		"<clientId>",
+		"<secret>",
+		"https://example-app.com/redirect",
+		client,
+		"name", "email")
+	session, _ := p.BeginAuth("test_state")
+
+	s := session.(*Session)
+
+	// Apple requires spaces to be encoded as %20 instead of +
+	a.Equal(s.AuthURL, "https://appleid.apple.com/auth/authorize?client_id=%3CclientId%3E&redirect_uri=https%3A%2F%2Fexample-app.com%2Fredirect&response_mode=form_post&response_type=code&scope=name%20email&state=test_state")
+}


### PR DESCRIPTION
We have been experiencing intermittent issues with Sign In With Apple when requesting email **and** name scopes. There's no error that is surfaced, but oftentimes the name is not available on first authentication, even if the user allows it.

Honestly we were pretty stumped about this, and fortunately someone from Apple proactively reached out to my company saying they were seeing errors on their end because we were requesting scopes using the wrong encoding: `scope=name+email` instead of `scope=name%20email`. For reasons that are still unclear to us, this only seems to be a problem _sometimes_ (but still hundreds of occurrences a day for us).

This encoding is outside our control, and comes from default behavior in the `oauth2` package and how it escapes query parameters.

I'm open to suggestions for improvement, but I have included a rough approach that works and has caused our "missing name" errors to plummet when testing.