### PR TITLE
Run Actions on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,10 @@
-on: [pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 name: ci
 


### PR DESCRIPTION
Run GitHub Actions on push to master, instead of just on PRs.