### PR TITLE
Add OuraRing provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ go get github.com/markbates/goth
 * Nextcloud
 * OneDrive
 * OpenID Connect (auto discovery)
+* Oura
 * Paypal
 * SalesForce
 * Shopify

--- a/providers/oura/errors.go
+++ b/providers/oura/errors.go
@@ -1,0 +1,16 @@
+package oura
+
+// APIError describes an error from the Oura API
+type APIError struct {
+	Code        int
+	Description string
+}
+
+// NewAPIError initializes an oura APIError
+func NewAPIError(code int, description string) APIError {
+	return APIError{code, description}
+}
+
+func (e APIError) Error() string {
+	return e.Description
+}

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -131,13 +131,26 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		return err
 	}
 
+	rawData := make(map[string]interface{})
+
+	if u.Age != 0 {
+		rawData["age"] = u.Age
+	}
+	if u.Weight != 0 {
+		rawData["weight"] = u.Weight
+	}
+	if u.Height != 0 {
+		rawData["height"] = u.Height
+	}
+	if u.Gender != "" {
+		rawData["gender"] = u.Gender
+	}
+
 	user.UserID = u.UserID
 	user.Email = u.Email
-	user.RawData = make(map[string]interface{})
-	user.RawData["age"] = u.Age
-	user.RawData["weight"] = u.Weight
-	user.RawData["height"] = u.Height
-	user.RawData["gender"] = u.Gender
+	if len(rawData) > 0 {
+		user.RawData = rawData
+	}
 
 	return err
 }

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -116,15 +116,14 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	return user, err
 }
 
-// TODO: Update for Oura format
 func userFromReader(reader io.Reader, user *goth.User) error {
 	u := struct {
-		User struct {
-			Avatar      string `json:"avatar"`
-			Country     string `json:"country"`
-			FullName    string `json:"fullName"`
-			DisplayName string `json:"displayName"`
-		} `json:"user"`
+		Age    int     `json:"age"`
+		Weight float32 `json:"weight"` // kg
+		Height int     `json:"height"` // cm
+		Gender string  `json:"gender"`
+		Email  string  `json:"email"`
+		UserID string  `json:"user_id"`
 	}{}
 
 	err := json.NewDecoder(reader).Decode(&u)
@@ -132,10 +131,13 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		return err
 	}
 
-	user.Location = u.User.Country
-	user.Name = u.User.FullName
-	user.NickName = u.User.DisplayName
-	user.AvatarURL = u.User.Avatar
+	user.UserID = u.UserID
+	user.Email = u.Email
+	user.RawData = make(map[string]interface{})
+	user.RawData["age"] = u.Age
+	user.RawData["weight"] = u.Weight
+	user.RawData["height"] = u.Height
+	user.RawData["gender"] = u.Gender
 
 	return err
 }

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -154,16 +154,8 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 		Scopes: []string{},
 	}
 
-	defaultScopes := map[string]struct{}{
-		ScopeEmail:    {},
-		ScopePersonal: {},
-		ScopeDaily:    {},
-	}
-
 	for _, scope := range scopes {
-		if _, exists := defaultScopes[scope]; !exists {
-			c.Scopes = append(c.Scopes, scope)
-		}
+		c.Scopes = append(c.Scopes, scope)
 	}
 
 	return c

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -61,6 +61,7 @@ func (p *Provider) SetName(name string) {
 	p.providerName = name
 }
 
+// Client for making requests on the provider
 func (p *Provider) Client() *http.Client {
 	return goth.HTTPClientWithFallBack(p.HTTPClient)
 }
@@ -108,7 +109,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+		return user, NewAPIError(resp.StatusCode, fmt.Sprintf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode))
 	}
 
 	//err = userFromReader(io.TeeReader(resp.Body, os.Stdout), &user)

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -1,0 +1,184 @@
+// Package oura implements the OAuth protocol for authenticating users through Oura API (for OuraRing).
+package oura
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"fmt"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+const (
+	authURL         string = "https://cloud.ouraring.com/oauth/authorize"
+	tokenURL        string = "https://api.ouraring.com/oauth/token"
+	endpointProfile string = "https://api.ouraring.com/v1/userinfo"
+)
+
+const (
+	// ScopeEmail includes email address of the user
+	ScopeEmail = "email"
+	// ScopePersonal includes personal information (gender, age, height, weight)
+	ScopePersonal = "personal"
+	// ScopeDaily includes daily summaries of sleep, activity and readiness
+	ScopeDaily = "daily"
+)
+
+// New creates a new Oura provider (for OuraRing), and sets up important connection details.
+// You should always call `oura.New` to get a new Provider. Never try to create
+// one manually.
+func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	p := &Provider{
+		ClientKey:    clientKey,
+		Secret:       secret,
+		CallbackURL:  callbackURL,
+		providerName: "oura",
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Provider is the implementation of `goth.Provider` for accessing Oura API.
+type Provider struct {
+	ClientKey    string
+	Secret       string
+	CallbackURL  string
+	HTTPClient   *http.Client
+	config       *oauth2.Config
+	providerName string
+}
+
+// Name is the name used to retrieve this provider later.
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
+}
+
+func (p *Provider) Client() *http.Client {
+	return goth.HTTPClientWithFallBack(p.HTTPClient)
+}
+
+// Debug is a no-op for the oura package.
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks Oura for an authentication end-point.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	url := p.config.AuthCodeURL(state)
+	session := &Session{
+		AuthURL: url,
+	}
+	return session, nil
+}
+
+// FetchUser will go to Oura and access basic information about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	s := session.(*Session)
+	user := goth.User{
+		AccessToken:  s.AccessToken,
+		Provider:     p.Name(),
+		RefreshToken: s.RefreshToken,
+		ExpiresAt:    s.ExpiresAt,
+		UserID:       s.UserID,
+	}
+
+	if user.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
+	}
+
+	req, err := http.NewRequest("GET", endpointProfile, nil)
+	if err != nil {
+		return user, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
+	resp, err := p.Client().Do(req)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return user, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
+	}
+
+	//err = userFromReader(io.TeeReader(resp.Body, os.Stdout), &user)
+	err = userFromReader(resp.Body, &user)
+	return user, err
+}
+
+// TODO: Update for Oura format
+func userFromReader(reader io.Reader, user *goth.User) error {
+	u := struct {
+		User struct {
+			Avatar      string `json:"avatar"`
+			Country     string `json:"country"`
+			FullName    string `json:"fullName"`
+			DisplayName string `json:"displayName"`
+		} `json:"user"`
+	}{}
+
+	err := json.NewDecoder(reader).Decode(&u)
+	if err != nil {
+		return err
+	}
+
+	user.Location = u.User.Country
+	user.Name = u.User.FullName
+	user.NickName = u.User.DisplayName
+	user.AvatarURL = u.User.Avatar
+
+	return err
+}
+
+func newConfig(provider *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     provider.ClientKey,
+		ClientSecret: provider.Secret,
+		RedirectURL:  provider.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
+		},
+		Scopes: []string{},
+	}
+
+	defaultScopes := map[string]struct{}{
+		ScopeEmail:    {},
+		ScopePersonal: {},
+		ScopeDaily:    {},
+	}
+
+	for _, scope := range scopes {
+		if _, exists := defaultScopes[scope]; !exists {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	}
+
+	return c
+}
+
+//RefreshToken get new access token based on the refresh token
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	token := &oauth2.Token{RefreshToken: refreshToken}
+	ts := p.config.TokenSource(oauth2.NoContext, token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return newToken, err
+}
+
+//RefreshTokenAvailable refresh token is not provided by oura
+func (p *Provider) RefreshTokenAvailable() bool {
+	return true
+}

--- a/providers/oura/oura_test.go
+++ b/providers/oura/oura_test.go
@@ -1,0 +1,55 @@
+package oura_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/oura"
+	"github.com/stretchr/testify/assert"
+)
+
+func provider() *oura.Provider {
+	return oura.New(os.Getenv("OURA_KEY"), os.Getenv("OURA_SECRET"), "/foo", "user")
+}
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+
+	a.Equal(p.ClientKey, os.Getenv("OURA_KEY"))
+	a.Equal(p.Secret, os.Getenv("OURA_SECRET"))
+	a.Equal(p.CallbackURL, "/foo")
+}
+
+func Test_ImplementsProvider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	a.Implements((*goth.Provider)(nil), provider())
+}
+
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	p := provider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*oura.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "https://cloud.ouraring.com/oauth/authorize")
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	p := provider()
+	session, err := p.UnmarshalSession(`{"AuthURL":"https://cloud.ouraring.com/oauth/authorize","AccessToken":"1234567890","UserID":"abc"}`)
+	a.NoError(err)
+
+	s := session.(*oura.Session)
+	a.Equal(s.AuthURL, "https://cloud.ouraring.com/oauth/authorize")
+	a.Equal(s.AccessToken, "1234567890")
+	a.Equal(s.UserID, "abc")
+}

--- a/providers/oura/session.go
+++ b/providers/oura/session.go
@@ -35,10 +35,13 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	if err != nil {
 		return "", err
 	}
+
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry
-	s.UserID = token.Extra("user_id").(string)
+	if userID, ok := token.Extra("user_id").(string); ok {
+		s.UserID = userID
+	}
 	return token.AccessToken, err
 }
 

--- a/providers/oura/session.go
+++ b/providers/oura/session.go
@@ -1,0 +1,61 @@
+package oura
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+// Session stores data during the auth process with Oura.
+type Session struct {
+	AuthURL      string
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+	UserID       string
+}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the
+// Oura provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize completes the the authorization with Oura and returns the access
+// token to be stored for future use.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+	if err != nil {
+		return "", err
+	}
+	s.AccessToken = token.AccessToken
+	s.RefreshToken = token.RefreshToken
+	s.ExpiresAt = token.Expiry
+	s.UserID = token.Extra("user_id").(string)
+	return token.AccessToken, err
+}
+
+// Marshal marshals a session into a JSON string.
+func (s Session) Marshal() string {
+	j, _ := json.Marshal(s)
+	return string(j)
+}
+
+// String is equivalent to Marshal.  It returns a JSON representation of the session.
+func (s Session) String() string {
+	return s.Marshal()
+}
+
+// UnmarshalSession will unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	s := Session{}
+	err := json.Unmarshal([]byte(data), &s)
+	return &s, err
+}

--- a/providers/oura/session_test.go
+++ b/providers/oura/session_test.go
@@ -1,0 +1,38 @@
+package oura_test
+
+import (
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/oura"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ImplementsSession(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &oura.Session{}
+	a.Implements((*goth.Session)(nil), s)
+}
+
+func Test_GetAuthURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &oura.Session{}
+
+	_, err := s.GetAuthURL()
+	a.Error(err)
+
+	s.AuthURL = "/foo"
+	url, _ := s.GetAuthURL()
+	a.Equal(url, "/foo")
+}
+
+func Test_ToJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &oura.Session{}
+
+	data := s.Marshal()
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z","UserID":""}`)
+}


### PR DESCRIPTION
Add provider for the OuraRing API, which uses OAuth2

https://cloud.ouraring.com/docs/authentication

Resolves #376 

I heavily patterned this provider on the existing fitbit provider, since the use cases are similar. I have done some bare bones manual testing against the API and confirmed that Authorize workflow as well as FetchUser and RefreshToken are functional in the way I expect.