### PR TITLE
Move the discord provider to the new discord url

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	authURL      string = "https://discordapp.com/api/oauth2/authorize"
-	tokenURL     string = "https://discordapp.com/api/oauth2/token"
-	userEndpoint string = "https://discordapp.com/api/users/@me"
+	authURL      string = "https://discord.com/api/oauth2/authorize"
+	tokenURL     string = "https://discord.com/api/oauth2/token"
+	userEndpoint string = "https://discord.com/api/users/@me"
 )
 
 const (

--- a/providers/discord/discord_test.go
+++ b/providers/discord/discord_test.go
@@ -37,7 +37,7 @@ func Test_BeginAuth(t *testing.T) {
 	session, err := p.BeginAuth("test_state")
 	s := session.(*Session)
 	a.NoError(err)
-	a.Contains(s.AuthURL, "discordapp.com/api/oauth2/authorize")
+	a.Contains(s.AuthURL, "discord.com/api/oauth2/authorize")
 }
 
 func Test_SessionFromJSON(t *testing.T) {
@@ -45,10 +45,10 @@ func Test_SessionFromJSON(t *testing.T) {
 	a := assert.New(t)
 
 	p := provider()
-	session, err := p.UnmarshalSession(`{"AuthURL":"https://discordapp.com/api/oauth2/authorize", "AccessToken":"1234567890"}`)
+	session, err := p.UnmarshalSession(`{"AuthURL":"https://discord.com/api/oauth2/authorize", "AccessToken":"1234567890"}`)
 	a.NoError(err)
 
 	s := session.(*Session)
-	a.Equal(s.AuthURL, "https://discordapp.com/api/oauth2/authorize")
+	a.Equal(s.AuthURL, "https://discord.com/api/oauth2/authorize")
 	a.Equal(s.AccessToken, "1234567890")
 }


### PR DESCRIPTION
Discord has moved their api and site to discord.com but the provider is still using discordapp.com

[Discord Developers](https://discord.gg/discord-developers)
[Message](https://canary.discord.com/channels/613425648685547541/697138785317814292/706944540971630662)