### PR TITLE
Add login_hint parameter to Google provider

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -184,3 +184,13 @@ func (p *Provider) SetHostedDomain(hd string) {
 	}
 	p.authCodeOptions = append(p.authCodeOptions, oauth2.SetAuthURLParam("hd", hd))
 }
+
+// SetLoginHint sets the login_hint parameter for the google OAuth call.
+// Use this to prompt the user to login with a specific account.
+// See https://developers.google.com/identity/protocols/oauth2/openid-connect#login-hint
+func (p *Provider) SetLoginHint(loginHint string) {
+	if loginHint == "" {
+		return
+	}
+	p.authCodeOptions = append(p.authCodeOptions, oauth2.SetAuthURLParam("login_hint", loginHint))
+}

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -72,6 +72,25 @@ func Test_BeginAuthWithHostedDomain(t *testing.T) {
 	a.Contains(s.AuthURL, "hd=example.com")
 }
 
+func Test_BeginAuthWithLoginHint(t *testing.T) {
+	// This exists because there was a panic caused by the oauth2 package when
+	// the AuthCodeOption passed was nil. This test uses it, Test_BeginAuth does
+	// not, to ensure both cases are covered.
+	t.Parallel()
+	a := assert.New(t)
+
+	provider := googleProvider()
+	provider.SetLoginHint("john@example.com")
+	session, err := provider.BeginAuth("test_state")
+	s := session.(*google.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "accounts.google.com/o/oauth2/auth")
+	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("GOOGLE_KEY")))
+	a.Contains(s.AuthURL, "state=test_state")
+	a.Contains(s.AuthURL, "scope=email")
+	a.Contains(s.AuthURL, "login_hint=john%40example.com")
+}
+
 func Test_Implements_Provider(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)


### PR DESCRIPTION
Similar to markbates/goth#325, adds support for the `login_hint` parameter so a specific email/account can be authenticated.