### PR TITLE
Export OpenIDConfig in openIdConnect provider

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -54,8 +54,8 @@ type Provider struct {
 	Secret       string
 	CallbackURL  string
 	HTTPClient   *http.Client
+	OpenIDConfig *OpenIDConfig
 	config       *oauth2.Config
-	openIDConfig *OpenIDConfig
 	providerName string
 
 	UserIdClaims    []string
@@ -106,7 +106,7 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 	if err != nil {
 		return nil, err
 	}
-	p.openIDConfig = openIDConfig
+	p.OpenIDConfig = openIDConfig
 
 	p.config = newConfig(p, scopes, openIDConfig)
 	return p, nil
@@ -216,7 +216,7 @@ func (p *Provider) validateClaims(claims map[string]interface{}) (time.Time, err
 	}
 
 	issuer := getClaimValue(claims, []string{issuerClaim})
-	if issuer != p.openIDConfig.Issuer {
+	if issuer != p.OpenIDConfig.Issuer {
 		return time.Time{}, errors.New("issuer in token does not match issuer in OpenIDConfig discovery")
 	}
 
@@ -245,11 +245,11 @@ func (p *Provider) userFromClaims(claims map[string]interface{}, user *goth.User
 
 func (p *Provider) getUserInfo(accessToken string, claims map[string]interface{}) error {
 	// skip if there is no UserInfoEndpoint or is explicitly disabled
-	if p.openIDConfig.UserInfoEndpoint == "" || p.SkipUserInfoRequest {
+	if p.OpenIDConfig.UserInfoEndpoint == "" || p.SkipUserInfoRequest {
 		return nil
 	}
 
-	userInfoClaims, err := p.fetchUserInfo(p.openIDConfig.UserInfoEndpoint, accessToken)
+	userInfoClaims, err := p.fetchUserInfo(p.OpenIDConfig.UserInfoEndpoint, accessToken)
 	if err != nil {
 		return err
 	}

--- a/providers/openidConnect/openidConnect_test.go
+++ b/providers/openidConnect/openidConnect_test.go
@@ -30,10 +30,10 @@ func Test_New(t *testing.T) {
 	a.Equal(os.Getenv("OPENID_CONNECT_SECRET"), provider.Secret)
 	a.Equal("http://localhost/foo", provider.CallbackURL)
 
-	a.Equal("https://accounts.google.com", provider.openIDConfig.Issuer)
-	a.Equal("https://accounts.google.com/o/oauth2/v2/auth", provider.openIDConfig.AuthEndpoint)
-	a.Equal("https://www.googleapis.com/oauth2/v4/token", provider.openIDConfig.TokenEndpoint)
-	a.Equal("https://www.googleapis.com/oauth2/v3/userinfo", provider.openIDConfig.UserInfoEndpoint)
+	a.Equal("https://accounts.google.com", provider.OpenIDConfig.Issuer)
+	a.Equal("https://accounts.google.com/o/oauth2/v2/auth", provider.OpenIDConfig.AuthEndpoint)
+	a.Equal("https://www.googleapis.com/oauth2/v4/token", provider.OpenIDConfig.TokenEndpoint)
+	a.Equal("https://www.googleapis.com/oauth2/v3/userinfo", provider.OpenIDConfig.UserInfoEndpoint)
 }
 
 func Test_BeginAuth(t *testing.T) {


### PR DESCRIPTION
This PR exports the `OpenIDConfig` field in the `openIdConnect` provider. The user may want to roll their logic when attempting to utilize the endpoints defined in `OpenIDConfig` such as the `AuthEndpoint` or the `RefreshEndpoint`.

In my case, the internal `RefreshToken` call isn't sufficient; it utilizes the external `oauth` library's `RefreshToken` call that unmarshalls the refresh token response into a struct containing `AccessToken` and `RefreshToken`, discarding the refreshed `id_token` in the response body (part of the [OpenID Connect spec](url)). Since `id_token` isn't a part of the core oauth spec, either the `RefreshToken` call needs to roll its own request, or alternatively, export the configuration that provides the refresh endpoint which allows the user to utilize it as they wish.