### PR TITLE
Properly fixed discord's avatar

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -165,12 +165,15 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	//If this prefix is present, the image should be available as a gif,
 	//See : https://discord.com/developers/docs/reference#image-formatting
 	//Introduced by : Yyewolf
-	avatarExtension := ".jpg"
-	prefix := "a_"
-	if len(u.AvatarID) >= len(prefix) && u.AvatarID[0:len(prefix)] == prefix {
-		avatarExtension = ".gif"
+
+	if u.AvatarID != "" {
+		avatarExtension := ".jpg"
+		prefix := "a_"
+		if len(u.AvatarID) >= len(prefix) && u.AvatarID[0:len(prefix)] == prefix {
+			avatarExtension = ".gif"
+		}
+		user.AvatarURL = "https://media.discordapp.net/avatars/" + u.ID + "/" + u.AvatarID + avatarExtension
 	}
-	user.AvatarURL = "https://media.discordapp.net/avatars/" + u.ID + "/" + u.AvatarID + avatarExtension
 
 	user.Name = u.Name
 	user.Email = u.Email


### PR DESCRIPTION
Commit 4c48aa7 reverted my changes, I included their modifications to mine according to what they changed.

Discord u.AvatarURL will be gifs if needed, jpg if they can't be gifs, and empty if u.AvatarID is empty.
