### PR TITLE
Add a Refresh Token function to the OpenID Connect provider that also returns the refreshed OpenID id_token

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -81,12 +81,11 @@ type OpenIDConfig struct {
 type RefreshTokenResponse struct {
 	AccessToken string `json:"access_token"`
 
-
 	// The OpenID spec defines the ID token as an optional response field in the
 	// refresh token flow. As a result, a new ID token may not be returned in a successful
 	// response.
 	// See more: https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
-	IdToken     string `json:"id_token, omitempty"`
+	IdToken string `json:"id_token, omitempty"`
 
 	// The OAuth spec defines the refresh token as an optional response field in the
 	// refresh token flow. As a result, a new refresh token may not be returned in a successful

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -243,7 +243,7 @@ func (p *Provider) RefreshTokenWithIDToken(refreshToken string) (*RefreshTokenRe
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-	    return nil, err
+		return nil, err
 	}
 	resp.Body.Close()
 

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -86,7 +86,7 @@ type RefreshTokenResponse struct {
 	// refresh token flow. As a result, a new refresh token may not be returned in a successful
 	// response.
 	//See more: https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/
-	RefreshToken     string `json:"refresh_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
 // New creates a new OpenID Connect provider, and sets up important connection details.
@@ -223,7 +223,7 @@ func (p *Provider) RefreshTokenWithIDToken(refreshToken string) (*RefreshTokenRe
 	}
 	req, err := http.NewRequest("POST", p.OpenIDConfig.TokenEndpoint, strings.NewReader(urlValues.Encode()))
 	if err != nil {
-		return nil,err
+		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -242,6 +242,9 @@ func (p *Provider) RefreshTokenWithIDToken(refreshToken string) (*RefreshTokenRe
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+	    return nil, err
+	}
 	resp.Body.Close()
 
 	refreshTokenResponse := &RefreshTokenResponse{}

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -234,9 +234,11 @@ func (p *Provider) RefreshTokenWithIDToken(refreshToken string) (*RefreshTokenRe
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := p.Client().Do(req)
-
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-200 response from RefreshToken: %d, WWW-Authenticate=%s", resp.StatusCode, resp.Header.Get("WWW-Authenticate"))
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -245,7 +247,7 @@ func (p *Provider) RefreshTokenWithIDToken(refreshToken string) (*RefreshTokenRe
 	refreshTokenResponse := &RefreshTokenResponse{}
 
 	err = json.Unmarshal(body, refreshTokenResponse)
-	if err != nil || refreshTokenResponse.IdToken == "" {
+	if err != nil {
 		return nil, err
 	}
 

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -80,7 +80,13 @@ type OpenIDConfig struct {
 
 type RefreshTokenResponse struct {
 	AccessToken string `json:"access_token"`
-	IdToken     string `json:"id_token"`
+
+
+	// The OpenID spec defines the ID token as an optional response field in the
+	// refresh token flow. As a result, a new ID token may not be returned in a successful
+	// response.
+	// See more: https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
+	IdToken     string `json:"id_token, omitempty"`
 
 	// The OAuth spec defines the refresh token as an optional response field in the
 	// refresh token flow. As a result, a new refresh token may not be returned in a successful


### PR DESCRIPTION
[The ID token is a fundamental part of the OpenID connect refresh token flow](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) (`id_token`). but is not part of the OAuth flow.

The existing `RefreshToken` function in the OpenID Connect provider leverages the OAuth library's refresh token mechanism, ignoring the optionally refreshed `id_token`. As a result, a new function needs to be exposed (rather than changing the existing function, for backwards compatibility purposes) that also returns the `id_token` in the OpenID refresh token flow API response. 

This PR creates and exposes such a flow with the function `RefreshTokenWithIDToken`. I've written this logic internally for our project at Tesla because we cannot use the `RefreshToken` endpoint due to it discarding the `id_token` response field, but figured it should be a part of the original `goth` library since this logic conforms to the Open ID connect spec.