### PR TITLE
Include end_session_endpoint in OpenIDConfig when retrieving the OpenID configuration from the OpenID Discovery endpoint

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -74,7 +74,12 @@ type OpenIDConfig struct {
 	AuthEndpoint     string `json:"authorization_endpoint"`
 	TokenEndpoint    string `json:"token_endpoint"`
 	UserInfoEndpoint string `json:"userinfo_endpoint"`
-	Issuer           string `json:"issuer"`
+
+	// If OpenID discovery is enabled, the end_session_endpoint field can optionally be provided
+	// in the discovery endpoint response according to OpenID spec. See:
+	// https://openid.net/specs/openid-connect-session-1_0-17.html#OPMetadata
+	EndSessionEndpoint string `json:"end_session_endpoint, omitempty"`
+	Issuer             string `json:"issuer"`
 }
 
 // New creates a new OpenID Connect provider, and sets up important connection details.


### PR DESCRIPTION
If OpenID discovery is enabled, the `end_session_endpoint` field can optionally be provided in the discovery endpoint response according to OpenID spec. This PR unmarshals the optional `end_session_endpoint` field into the discovery endpoint response. Our discovery endpoint at Tesla includes this field in the response but `goth` does not including the field into the unmarshaled struct, forcing us to inject the URL manually (or roll our own API call to the discovery URL).

See: 

- [OpenID Connect draft](https://openid.net/specs/openid-connect-session-1_0-17.html#OPMetadata)
- [connect2Id (OpenID implementation) docs regarding end_session_endpoint](https://connect2id.com/products/server/docs/api/logout)

