### PR TITLE
Add NewCustomisedURL function to the OpenID connect provider

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -134,6 +134,36 @@ func New(clientKey, secret, callbackURL, openIDAutoDiscoveryURL string, scopes .
 	return p, nil
 }
 
+// NewCustomisedURL is similar to New(...) but can be used to set custom URLs hence omit the auto-discovery step
+func NewCustomisedURL(clientKey, secret, callbackURL, authURL, tokenURL, issuerURL, userInfoURL, endSessionEndpointURL string, scopes ...string) (*Provider, error) {
+	p := &Provider{
+		ClientKey:   clientKey,
+		Secret:      secret,
+		CallbackURL: callbackURL,
+		OpenIDConfig: &OpenIDConfig{
+			AuthEndpoint:       authURL,
+			TokenEndpoint:      tokenURL,
+			Issuer:             issuerURL,
+			UserInfoEndpoint:   userInfoURL,
+			EndSessionEndpoint: endSessionEndpointURL,
+		},
+
+		UserIdClaims:    []string{subjectClaim},
+		NameClaims:      []string{NameClaim},
+		NickNameClaims:  []string{NicknameClaim, PreferredUsernameClaim},
+		EmailClaims:     []string{EmailClaim},
+		AvatarURLClaims: []string{PictureClaim},
+		FirstNameClaims: []string{GivenNameClaim},
+		LastNameClaims:  []string{FamilyNameClaim},
+		LocationClaims:  []string{AddressClaim},
+
+		providerName: "openid-connect",
+	}
+
+	p.config = newConfig(p, scopes, p.OpenIDConfig)
+	return p, nil
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/openidConnect/openidConnect_test.go
+++ b/providers/openidConnect/openidConnect_test.go
@@ -36,6 +36,32 @@ func Test_New(t *testing.T) {
 	a.Equal("https://www.googleapis.com/oauth2/v3/userinfo", provider.OpenIDConfig.UserInfoEndpoint)
 }
 
+func Test_NewCustomisedURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	provider, _ := NewCustomisedURL(
+		os.Getenv("OPENID_CONNECT_KEY"),
+		os.Getenv("OPENID_CONNECT_SECRET"),
+		"http://localhost/foo",
+		"https://accounts.google.com/o/oauth2/v2/auth",
+		"https://www.googleapis.com/oauth2/v4/token",
+		"https://accounts.google.com",
+		"https://www.googleapis.com/oauth2/v3/userinfo",
+		"",
+		server.URL,
+	)
+	a.Equal(os.Getenv("OPENID_CONNECT_KEY"), provider.ClientKey)
+	a.Equal(os.Getenv("OPENID_CONNECT_SECRET"), provider.Secret)
+	a.Equal("http://localhost/foo", provider.CallbackURL)
+
+	a.Equal("https://accounts.google.com", provider.OpenIDConfig.Issuer)
+	a.Equal("https://accounts.google.com/o/oauth2/v2/auth", provider.OpenIDConfig.AuthEndpoint)
+	a.Equal("https://www.googleapis.com/oauth2/v4/token", provider.OpenIDConfig.TokenEndpoint)
+	a.Equal("https://www.googleapis.com/oauth2/v3/userinfo", provider.OpenIDConfig.UserInfoEndpoint)
+	a.Equal("", provider.OpenIDConfig.EndSessionEndpoint)
+}
+
 func Test_BeginAuth(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)


### PR DESCRIPTION
Currently, there was no function to use the OpenID connect provider without auto-discovery, but I think this one is a possible use case for others too. 