### PR TITLE
PNG avatars

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -167,7 +167,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	//Introduced by : Yyewolf
 
 	if u.AvatarID != "" {
-		avatarExtension := ".jpg"
+		avatarExtension := ".png"
 		prefix := "a_"
 		if len(u.AvatarID) >= len(prefix) && u.AvatarID[0:len(prefix)] == prefix {
 			avatarExtension = ".gif"


### PR DESCRIPTION
Use a png instead of a jpg to support avatars that have transparency 