### PR TITLE
[oidc] error on unsuccessful Discovery URL

### DIFF
--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -79,7 +79,7 @@ type OpenIDConfig struct {
 	// If OpenID discovery is enabled, the end_session_endpoint field can optionally be provided
 	// in the discovery endpoint response according to OpenID spec. See:
 	// https://openid.net/specs/openid-connect-session-1_0-17.html#OPMetadata
-	EndSessionEndpoint string `json:"end_session_endpoint, omitempty"`
+	EndSessionEndpoint string `json:"end_session_endpoint,omitempty"`
 	Issuer             string `json:"issuer"`
 }
 
@@ -373,6 +373,10 @@ func getOpenIDConfig(p *Provider, openIDAutoDiscoveryURL string) (*OpenIDConfig,
 		return nil, err
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("Non-success code for Discovery URL: %d", res.StatusCode)
+	}
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
The issue
---------

For *Discovery URL*s that did not generate a successful *HTTP status code*, no error was returned when instantiating the *OpenID Connect* provider. This resulted in `openidConnect.New ()` appearing successful on *Discovery URL*s that did return a valid *JSON* and a non-success HTTP *status code* as well.

This makes it difficult to check whether the provider's instantiation was successful or not.

Further analysis
----------------

An example of this is the *Discovery URL* [login.microsoftonline.com/unknown-tenant/v2.0/.well-known/openid-configuration](https://login.microsoftonline.com/unknown-tenant/v2.0/.well-known/openid-configuration) (the tenant does not exist). The resulting *JSON* looks like this:

```JSON
{
    "error": "invalid_tenant",
    "error_description": "AADSTS90002: Tenant 'unknown-tenant'
not found. This may happen if there are no active subscriptions
for the tenant. Check to make sure you have the correct tenant ID.
Check with your subscription administrator.\r\nTrace ID:
5982dc19-d48d-4d2f-bdbb-956704df6a00\r\nCorrelation ID:
156dbcd3-4546-40b5-b656-350fd7b6453a\r\nTimestamp:
2021-04-19 14:30:03Z",
    "error_codes": [90002],
    "timestamp": "2021-04-19 14:30:03Z",
    "trace_id": "5982dc19-d48d-4d2f-bdbb-956704df6a00",
    "correlation_id": "156dbcd3-4546-40b5-b656-350fd7b6453a",
    "error_uri": "https://login.microsoftonline.com/error?code=90002"
}
```

As a result `AuthEndpoint`, `TokenEndpoint` and `Issuer` will be empty in `OpenIDConfig` and errors will occur later during the actual authentication.


The solution
------------

This PR:

1. Checks the *HTTP status code* returned by the *Discovery URL*.
2. Fixes a minor typing error in the *JSON* tag for `EndSessionEndpoint`.
