### PR TITLE
Make it possible to set bot_prompt query param for line

### DIFF
--- a/providers/line/line.go
+++ b/providers/line/line.go
@@ -22,12 +22,13 @@ const (
 
 // Provider is the implementation of `goth.Provider` for accessing Line.me.
 type Provider struct {
-	ClientKey    string
-	Secret       string
-	CallbackURL  string
-	HTTPClient   *http.Client
-	config       *oauth2.Config
-	providerName string
+	ClientKey       string
+	Secret          string
+	CallbackURL     string
+	HTTPClient      *http.Client
+	config          *oauth2.Config
+	authCodeOptions []oauth2.AuthCodeOption
+	providerName    string
 }
 
 // New creates a new Line provider and sets up important connection details.
@@ -65,7 +66,7 @@ func (p *Provider) Debug(debug bool) {}
 // BeginAuth asks line.me for an authentication end-point.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 	return &Session{
-		AuthURL: p.config.AuthCodeURL(state),
+		AuthURL: p.config.AuthCodeURL(state, p.authCodeOptions...),
 	}, nil
 }
 
@@ -156,4 +157,14 @@ func (p *Provider) RefreshTokenAvailable() bool {
 //RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, nil
+}
+
+// SetBotPrompt sets the bot_prompt parameter for the line OAuth call.
+// Use this to display the option to add your LINE Official Account as a friend.
+// See https://developers.line.biz/en/docs/line-login/link-a-bot/#redirect-users
+func (p *Provider) SetBotPrompt(botPrompt string) {
+	if botPrompt == "" {
+		return
+	}
+	p.authCodeOptions = append(p.authCodeOptions, oauth2.SetAuthURLParam("bot_prompt", botPrompt))
 }

--- a/providers/line/line_test.go
+++ b/providers/line/line_test.go
@@ -57,7 +57,7 @@ func Test_SetBotPrompt(t *testing.T) {
 	session, err := p.BeginAuth("test_state")
 	s := session.(*line.Session)
 	a.NoError(err)
-	a.Contains(s.AuthURL, "&bot_prompt=normal")
+	a.Contains(s.AuthURL, "bot_prompt=normal")
 }
 
 func provider() *line.Provider {

--- a/providers/line/line_test.go
+++ b/providers/line/line_test.go
@@ -48,6 +48,18 @@ func Test_SessionFromJSON(t *testing.T) {
 	a.Equal(s.AccessToken, "1234567890")
 }
 
+func Test_SetBotPrompt(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	p := provider()
+	p.SetBotPrompt("normal")
+	session, err := p.BeginAuth("test_state")
+	s := session.(*line.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "&bot_prompt=normal")
+}
+
 func provider() *line.Provider {
 	return line.New(os.Getenv("LINE_CLIENT_ID"), os.Getenv("LINE_CLIENT_SECRET"), "/foo")
 }


### PR DESCRIPTION
To display the option to add your LINE Official Account as a friend, we need to pass `bot_prompt` query parameter for the auth url.
This PR adds `SetBotPrompt` function to set the query param.

details for the `bot_promt` is written in the document below.
https://developers.line.biz/en/docs/line-login/link-a-bot/#redirect-users

![bot-prompt 1dd4e585](https://user-images.githubusercontent.com/24503508/122226469-fc949180-cef0-11eb-92e3-8f54e5f59e2a.png)
