### PR TITLE
Allow Access to Discriminator for Discord

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -178,6 +178,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.Name = u.Name
 	user.Email = u.Email
 	user.UserID = u.ID
+	user.LastName = u.Discriminator
 
 	return nil
 }


### PR DESCRIPTION
Allow access to the Discord user's discriminator (tag) using LastName.

This is a simple one-line addition that allows access to the Discord tag (discriminator) using the goth.User's LastName field.

Ideally, it would go something like this:
user.Name `ExampleUser#1234`
user.FirstName `ExampleUser`
user.LastName `1234`

But implementing a system like that would be breaking for some users depending on user.Name to return the first part of the username, so this solution is probably best. If this commit it approved as-is, it will work like this:
user.Name `ExampleUser`
user.FirstName
user.LastName `1234`

If anyone has ideas/feedback, that would be greatly appreciated. It does not appear that tests need to be updated for this change.