### PR TITLE
Bump VK provider API version to 5.131

### DIFF
--- a/providers/vk/vk.go
+++ b/providers/vk/vk.go
@@ -20,7 +20,7 @@ var (
 	authURL      = "https://oauth.vk.com/authorize"
 	tokenURL     = "https://oauth.vk.com/access_token"
 	endpointUser = "https://api.vk.com/method/users.get"
-	apiVersion   = "5.71"
+	apiVersion   = "5.131"
 )
 
 // New creates a new VK provider and sets up important connection details.


### PR DESCRIPTION
Old API version was deprecated and is not working anymore

