### PR TITLE
Drop old Go versions, fix errors and fmt issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        go-version: [ 1.15.x, 1.16.x, 1.17.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/providers/google/session_test.go
+++ b/providers/google/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &google.Session{}
 
 	data := s.Marshal()
-	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z"}`)
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","RefreshToken":"","ExpiresAt":"0001-01-01T00:00:00Z","IDToken":""}`)
 }
 
 func Test_String(t *testing.T) {

--- a/providers/wecom/wecom.go
+++ b/providers/wecom/wecom.go
@@ -152,7 +152,7 @@ func (p *Provider) fetchToken() (*oauth2.Token, error) {
 
 	p.token = &oauth2.Token{
 		AccessToken: obj.AccessToken,
-		Expiry: time.Now().Add(obj.ExpiresIn * time.Second),
+		Expiry:      time.Now().Add(obj.ExpiresIn * time.Second),
 	}
 
 	return p.token, nil


### PR DESCRIPTION
* Drops CI support for older Go versions.
* Fixes a newly failing test in the Google provider, since the tests weren't running against PRs for some reason.
* Fixes a gofmt issue that was not caught by CI.