### PR TITLE
Add new Go 1.17 build tags

### DIFF
--- a/providers/google/endpoint.go
+++ b/providers/google/endpoint.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package google

--- a/providers/google/endpoint_legacy.go
+++ b/providers/google/endpoint_legacy.go
@@ -1,3 +1,4 @@
+//go:build !go1.9
 // +build !go1.9
 
 package google


### PR DESCRIPTION
Adds the new build tags for Go 1.17, as this caused master to fail the `gofmt` check.