### PR TITLE
TikTok Provider Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $ go get github.com/markbates/goth
 * Steam
 * Strava
 * Stripe
+* TikTok
 * Tumblr
 * Twitch
 * Twitter

--- a/examples/main.go
+++ b/examples/main.go
@@ -56,6 +56,7 @@ import (
 	"github.com/markbates/goth/providers/steam"
 	"github.com/markbates/goth/providers/strava"
 	"github.com/markbates/goth/providers/stripe"
+	"github.com/markbates/goth/providers/tiktok"
 	"github.com/markbates/goth/providers/twitch"
 	"github.com/markbates/goth/providers/twitter"
 	"github.com/markbates/goth/providers/typetalk"
@@ -76,6 +77,7 @@ func main() {
 		// If you'd like to use authenticate instead of authorize in Twitter provider, use this instead.
 		// twitter.NewAuthenticate(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
 
+		tiktok.New(os.Getenv("TIKTOK_KEY"), os.Getenv("TIKTOK_SECRET"), "http://localhost:3000/auth/tiktok/callback"),
 		facebook.New(os.Getenv("FACEBOOK_KEY"), os.Getenv("FACEBOOK_SECRET"), "http://localhost:3000/auth/facebook/callback"),
 		fitbit.New(os.Getenv("FITBIT_KEY"), os.Getenv("FITBIT_SECRET"), "http://localhost:3000/auth/fitbit/callback"),
 		google.New(os.Getenv("GOOGLE_KEY"), os.Getenv("GOOGLE_SECRET"), "http://localhost:3000/auth/google/callback"),
@@ -170,6 +172,7 @@ func main() {
 	m["spotify"] = "Spotify"
 	m["steam"] = "Steam"
 	m["stripe"] = "Stripe"
+	m["tiktok"] = "TikTok"
 	m["twitch"] = "Twitch"
 	m["uber"] = "Uber"
 	m["wepay"] = "Wepay"

--- a/providers/tiktok/session.go
+++ b/providers/tiktok/session.go
@@ -1,0 +1,104 @@
+package tiktok
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/markbates/goth"
+)
+
+// Session stores data during the auth process with TikTok
+type Session struct {
+	AuthURL          string
+	AccessToken      string
+	ExpiresAt        time.Time
+	OpenID           string
+	RefreshToken     string
+	RefreshExpiresAt time.Time
+}
+
+// GetAuthURL will return the URL set by calling the `BeginAuth` function on the TikTok provider.
+func (s Session) GetAuthURL() (string, error) {
+	if s.AuthURL == "" {
+		return "", errors.New(goth.NoAuthUrlErrorMessage)
+	}
+	return s.AuthURL, nil
+}
+
+// Authorize the session with TikTok and return the access token to be stored for future use. Note that
+// we call the endpoints directly vs calling *oauth2.Config.Exchange() due to inconsistent TikTok param names.
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	p := provider.(*Provider)
+
+	// Set up the url params to post to get a new access token from a code
+	v := url.Values{
+		"grant_type": {"authorization_code"},
+		"code":       {params.Get("code")},
+	}
+	if p.config.RedirectURL != "" {
+		v.Set("redirect_uri", p.config.RedirectURL)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, endpointToken, nil)
+	if err != nil {
+		return "", err
+	}
+	v.Add("client_key", p.config.ClientID)
+	v.Add("client_secret", p.config.ClientSecret)
+
+	req.URL.RawQuery = v.Encode()
+	response, err := p.GetClient().Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	tokenResp := struct {
+		Data struct {
+			OpenID           string `json:"open_id"`
+			Scope            string `json:"scope"`
+			AccessToken      string `json:"access_token"`
+			ExpiresIn        int64  `json:"expires_in"`
+			RefreshToken     string `json:"refresh_token"`
+			RefreshExpiresIn int64  `json:"refresh_expires_in"`
+		} `json:"data"`
+	}{}
+
+	// Get the body bytes in case we have to parse an error response
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	err = json.Unmarshal(bodyBytes, &tokenResp)
+	if err != nil {
+		return "", err
+	}
+
+	// If we do not have an access token we assume we have an error response payload
+	if tokenResp.Data.AccessToken == "" {
+		return "", handleErrorResponse(bodyBytes)
+	}
+
+	// Create and Bind the Access Token
+	s.AccessToken = tokenResp.Data.AccessToken
+	s.ExpiresAt = time.Now().UTC().Add(time.Second * time.Duration(tokenResp.Data.ExpiresIn))
+	s.OpenID = tokenResp.Data.OpenID
+	s.RefreshToken = tokenResp.Data.RefreshToken
+	s.RefreshExpiresAt = time.Now().UTC().Add(time.Second * time.Duration(tokenResp.Data.RefreshExpiresIn))
+	return s.AccessToken, nil
+}
+
+// Marshal the session into a string
+func (s Session) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s Session) String() string {
+	return s.Marshal()
+}

--- a/providers/tiktok/session_test.go
+++ b/providers/tiktok/session_test.go
@@ -1,0 +1,48 @@
+package tiktok_test
+
+import (
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/tiktok"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Implements_Session(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &tiktok.Session{}
+
+	a.Implements((*goth.Session)(nil), s)
+}
+
+func Test_GetAuthURL(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &tiktok.Session{}
+
+	_, err := s.GetAuthURL()
+	a.Error(err)
+
+	s.AuthURL = "/foo"
+
+	url, _ := s.GetAuthURL()
+	a.Equal(url, "/foo")
+}
+
+func Test_ToJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &tiktok.Session{}
+
+	data := s.Marshal()
+	a.Equal(data, `{"AuthURL":"","AccessToken":"","ExpiresAt":"0001-01-01T00:00:00Z","OpenID":"","RefreshToken":"","RefreshExpiresAt":"0001-01-01T00:00:00Z"}`)
+}
+
+func Test_String(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	s := &tiktok.Session{}
+
+	a.Equal(s.String(), s.Marshal())
+}

--- a/providers/tiktok/tiktok.go
+++ b/providers/tiktok/tiktok.go
@@ -1,0 +1,279 @@
+// Package tiktok implements the OAuth2 protocol for authenticating users through TikTok.
+// This package can be used as a reference implementation of an OAuth2 provider for Goth.
+package tiktok
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+const (
+	endpointAuth     = "https://open-api.tiktok.com/platform/oauth/connect/"
+	endpointToken    = "https://open-api.tiktok.com/oauth/access_token/"
+	endpointRefresh  = "https://open-api.tiktok.com/oauth/refresh_token/"
+	endpointUserInfo = "https://open-api.tiktok.com/oauth/userinfo/"
+
+	ScopeUserInfoBasic    = "user.info.basic"
+	ScopeVideoList        = "video.list"
+	ScopeVideoUpload      = "video.upload"
+	ScopeShareSoundCreate = "share.sound.create"
+)
+
+// Provider is the implementation of `goth.Provider` for accessing TikTok
+type Provider struct {
+	CallbackURL  string
+	Client       *http.Client
+	ClientKey    string
+	ClientSecret string
+	config       *oauth2.Config
+	providerName string
+}
+
+// New creates a new TikTok provider, and sets up connection details.
+func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
+	p := &Provider{
+		ClientKey:    clientKey,
+		ClientSecret: secret,
+		CallbackURL:  callbackURL,
+		providerName: "tiktok",
+	}
+	p.config = newConfig(p, scopes)
+	return p
+}
+
+// Name is the name used to retrieve this provider.
+func (p *Provider) Name() string {
+	return p.providerName
+}
+
+// SetName is to update the name of the provider (needed in case of multiple providers of 1 type)
+func (p *Provider) SetName(name string) {
+	p.providerName = name
+}
+
+func (p *Provider) GetClient() *http.Client {
+	return goth.HTTPClientWithFallBack(p.Client)
+}
+
+//Debug TODO
+func (p *Provider) Debug(debug bool) {}
+
+// BeginAuth asks TikTok for an authentication end-point. Note that we create our own URL string instead
+// of calling oauth2.AuthCodeURL() due to TikTok param name requirements.
+func (p *Provider) BeginAuth(state string) (goth.Session, error) {
+	var buf bytes.Buffer
+	buf.WriteString(p.config.Endpoint.AuthURL)
+	v := url.Values{
+		"response_type": {"code"},
+		"client_key":    {p.config.ClientID},
+		"state":         {state},
+	}
+
+	if p.config.RedirectURL != "" {
+		v.Set("redirect_uri", p.config.RedirectURL)
+	}
+
+	// Note scopes are CSVs
+	if len(p.config.Scopes) > 0 {
+		v.Set("scope", strings.Join(p.config.Scopes, ","))
+	}
+
+	if strings.Contains(p.config.Endpoint.AuthURL, "?") {
+		buf.WriteByte('&')
+	} else {
+		buf.WriteByte('?')
+	}
+	buf.WriteString(v.Encode())
+	return &Session{
+		AuthURL: buf.String(),
+	}, nil
+}
+
+// FetchUser will go to TikTok and access basic information about the user.
+func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
+	sess := session.(*Session)
+	user := goth.User{
+		AccessToken:  sess.AccessToken,
+		ExpiresAt:    sess.ExpiresAt,
+		Provider:     p.Name(),
+		RefreshToken: sess.RefreshToken,
+		UserID:       sess.OpenID,
+	}
+
+	// data is not yet retrieved since accessToken is still empty
+	if user.AccessToken == "" || user.UserID == "" {
+		return user, fmt.Errorf("%s cannot get user information without accessToken and userID", p.providerName)
+	}
+
+	// Set up the url params to post to get a new access token from a code
+	v := url.Values{
+		"access_token": {user.AccessToken},
+		"open_id":      {user.UserID},
+	}
+	response, err := p.GetClient().Get(endpointUserInfo + "?" + v.Encode())
+	if err != nil {
+		return user, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
+	}
+
+	err = userFromReader(response.Body, &user)
+	response.Body.Close()
+	return user, err
+}
+
+func userFromReader(reader io.Reader, user *goth.User) error {
+	u := struct {
+		Data struct {
+			OpenID      string `json:"open_id"`
+			Avatar      string `json:"avatar"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}{}
+
+	bodyBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bodyBytes, &u)
+	if err != nil {
+		return err
+	}
+	user.AvatarURL = u.Data.Avatar
+	user.Name = u.Data.DisplayName
+	user.NickName = u.Data.DisplayName
+
+	// On no display name, we assume an error response. TikTok returns error codes and descriptions inside
+	// the same struct/body. Sigh...refer https://developers.tiktok.com/doc/login-kit-user-info-basic
+	if user.Name == "" {
+		return handleErrorResponse(bodyBytes)
+	}
+
+	// Bind the all the bytes to the raw data returning err
+	return json.Unmarshal(bodyBytes, &user.RawData)
+}
+
+func newConfig(p *Provider, scopes []string) *oauth2.Config {
+	c := &oauth2.Config{
+		ClientID:     p.ClientKey,
+		ClientSecret: p.ClientSecret,
+		RedirectURL:  p.CallbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL: endpointAuth,
+		},
+		Scopes: []string{ScopeUserInfoBasic},
+	}
+
+	// Note that the "user.info.basic" scope is always bound so don't dupe
+	for _, scope := range scopes {
+		if scope != ScopeUserInfoBasic {
+			c.Scopes = append(c.Scopes, scope)
+		}
+	}
+
+	return c
+}
+
+// RefreshToken will refresh a TikTok access token.
+func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	req, err := http.NewRequest(http.MethodPost, endpointRefresh, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up the url params to post to get a new access token from a code
+	v := url.Values{
+		"client_key":    {p.config.ClientID},
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}
+	req.URL.RawQuery = v.Encode()
+	refreshResponse, err := p.GetClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// We get the body bytes in case we need to parse an error response
+	bodyBytes, err := ioutil.ReadAll(refreshResponse.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer refreshResponse.Body.Close()
+
+	refresh := struct {
+		Data struct {
+			OpenID           string `json:"open_id"`
+			Scope            string `json:"scope"`
+			AccessToken      string `json:"access_token"`
+			ExpiresIn        int64  `json:"expires_in"`
+			RefreshToken     string `json:"refresh_token"`
+			RefreshExpiresIn int64  `json:"refresh_expires_in"`
+		} `json:"data"`
+	}{}
+	err = json.Unmarshal(bodyBytes, &refresh)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we do not have an access token we assume we have an error response payload
+	if refresh.Data.AccessToken == "" {
+		return nil, handleErrorResponse(bodyBytes)
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  refresh.Data.AccessToken,
+		TokenType:    "Bearer",
+		RefreshToken: refresh.Data.RefreshToken,
+		Expiry:       time.Now().Add(time.Second * time.Duration(refresh.Data.ExpiresIn)),
+	}
+
+	tokenExtra := map[string]interface{}{
+		"open_id":            refresh.Data.OpenID,
+		"scope":              refresh.Data.Scope,
+		"refresh_expires_in": refresh.Data.RefreshExpiresIn,
+	}
+
+	return token.WithExtra(tokenExtra), nil
+}
+
+// RefreshTokenAvailable refresh token
+func (p *Provider) RefreshTokenAvailable() bool {
+	return true
+}
+
+// UnmarshalSession will unmarshal a JSON string into a session.
+func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
+	s := &Session{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(s)
+	return s, err
+}
+
+func handleErrorResponse(data []byte) error {
+	errResp := struct {
+		Data struct {
+			Captcha     string `json:"captcha"`
+			DescURL     string `json:"desc_url"`
+			Description string `json:"description"`
+			ErrorCode   int    `json:"error_code"`
+		} `json:"data"`
+		Message string `json:"message"`
+	}{}
+	if err := json.Unmarshal(data, &errResp); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("%s [%d]", errResp.Data.Description, errResp.Data.ErrorCode)
+}

--- a/providers/tiktok/tiktok_test.go
+++ b/providers/tiktok/tiktok_test.go
@@ -1,0 +1,59 @@
+package tiktok_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/tiktok"
+	"github.com/stretchr/testify/assert"
+)
+
+const callbackURL = "/tests/for/the/win"
+
+func Test_New(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+
+	a.Equal(p.ClientKey, os.Getenv("tiktok_KEY"))
+	a.Equal(p.ClientSecret, os.Getenv("tiktok_SECRET"))
+	a.Nil(p.Client)
+	a.Equal(p.CallbackURL, callbackURL)
+}
+
+func Test_Implements_Provider(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	a.Implements((*goth.Provider)(nil), provider())
+}
+
+func Test_BeginAuth(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	p := provider()
+	session, err := p.BeginAuth("test_state")
+	s := session.(*tiktok.Session)
+	a.NoError(err)
+	a.Contains(s.AuthURL, "https://open-api.tiktok.com/platform/oauth/connect")
+	a.Contains(s.AuthURL, fmt.Sprintf("%s%%2C%s", tiktok.ScopeUserInfoBasic, tiktok.ScopeVideoList))
+}
+
+func Test_SessionFromJSON(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	p := provider()
+	session, err := p.UnmarshalSession(`{"AuthURL":"https://open-api.tiktok.com/platform/oauth/connect","AccessToken":"1234567890"}"`)
+	a.NoError(err)
+
+	s := session.(*tiktok.Session)
+	a.Equal(s.AuthURL, "https://open-api.tiktok.com/platform/oauth/connect")
+	a.Equal(s.AccessToken, "1234567890")
+}
+
+func provider() *tiktok.Provider {
+	p := tiktok.New(os.Getenv("tiktok_KEY"), os.Getenv("tiktok_SECRET"), callbackURL, tiktok.ScopeVideoList)
+	return p
+}

--- a/providers/tiktok/tiktok_test.go
+++ b/providers/tiktok/tiktok_test.go
@@ -54,6 +54,6 @@ func Test_SessionFromJSON(t *testing.T) {
 }
 
 func provider() *tiktok.Provider {
-	p := tiktok.New(os.Getenv("tiktok_KEY"), os.Getenv("tiktok_SECRET"), callbackURL, tiktok.ScopeVideoList)
+	p := tiktok.New(os.Getenv("TIKTOK_KEY"), os.Getenv("TIKTOK_SECRET"), callbackURL, tiktok.ScopeVideoList)
 	return p
 }


### PR DESCRIPTION
Addition of the TikTok provider for oauth2 flows. Addition includes
RefreshToken logic as well as default authorise/connect.

Currently running in a production environment with https://feed.army as
a bespoke auth provider. But no reason why this can not be given back to
the community =]