### PR TITLE
Migrate from v5 Twitch API to Helix

### DIFF
--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -4,6 +4,7 @@ package twitch
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -20,58 +21,132 @@ const (
 )
 
 const (
-	// ScopeChannelCheckSubscription provides access to read whether a user is
-	// subscribed to your channel.
-	ScopeChannelCheckSubscription string = "channel_check_subscription"
-	// ScopeChannelCommercial provides access to trigger commercials on
+	// ScopeAnalyticsReadExtensions provides access to view analytics data for
+	// the Twitch Extensions owned by the authenticated account.
+	ScopeAnalyticsReadExtensions string = "analytics:read:extensions"
+	// ScopeAnalyticsReadGames provides accesss to view analytics data for the
+	// games owned by the authenticated account.
+	ScopeAnalyticsReadGames = "analytics:read:games"
+	// ScopeBitsRead provides access to view Bits information for a channel.
+	ScopeBitsRead = "bits:read"
+	// ScopeChannelEditCommercial provides access to run commercials on a
 	// channel.
-	ScopeChannelCommercial string = "channel_commercial"
-	// ScopeChannelEditor provides access to write channel metadata
-	// (game, status, etc).
-	ScopeChannelEditor string = "channel_editor"
-	// ScopeChannelFeedEdit provides access to add posts and reactions to a
-	// channel feed.
-	ScopeChannelFeedEdit string = "channel_feed_edit"
-	// ScopeChannelFeedRead provides access to view a channel feed.
-	ScopeChannelFeedRead string = "channel_feed_read"
-	// ScopeChannelRead provides access to read nonpublic channel information,
-	// including email address and stream key.
-	ScopeChannelRead string = "channel_read"
-	// ScopeChannelStream provides access to reset a channel’s stream key.
-	ScopeChannelStream string = "channel_stream"
-	// ScopeChannelSubscriptions provides access to read all subscribers to
-	// your channel.
-	ScopeChannelSubscriptions string = "channel_subscriptions"
-	// ScopeCollectionsEdit provides access to manage a user’s collections
-	// (of videos).
-	ScopeCollectionsEdit string = "collections_edit"
-	// ScopeCommunitiesEdit provides access to manage a user’s communities.
-	ScopeCommunitiesEdit string = "communities_edit"
-	// ScopeCommunitiesModerate provides access to manage community moderators.
-	ScopeCommunitiesModerate string = "communities_moderate"
-	// ScopeOpenID provides access to use OpenID Connect authentication.
-	ScopeOpenID string = "openid"
-	// ScopeUserBlocksEdit provides access to turn on/off ignoring a user.
-	// Ignoring users means you cannot see them type, receive messages from
-	// them, etc.
-	ScopeUserBlocksEdit string = "user_blocks_edit"
-	// ScopeUserBlocksRead provides access to read a user’s list of ignored
-	// users.
-	ScopeUserBlocksRead string = "user_blocks_read"
-	// ScopeUserFollowsEdit provides access to manage a user’s followed
-	// channels.
-	ScopeUserFollowsEdit string = "user_follows_edit"
-	// ScopeUserRead provides access to read nonpublic user information, like
-	// email address.
-	ScopeUserRead string = "user_read"
-	// ScopeUserSubscriptions provides access to read a user’s subscriptions.
-	ScopeUserSubscriptions string = "user_subscriptions"
-	// ScopeViewingActivityRead provides access to turn on Viewer Heartbeat
-	// Service ability to record user data.
-	ScopeViewingActivityRead string = "viewing_activity_read"
-	// ScopeChatLogin (Deprecated — cannot be requested by new clients.) Log
-	// into chat and send messages.
-	ScopeChatLogin string = "chat_login"
+	ScopeChannelEditCommercial = "channel:edit:commercial"
+	// ScopeChannelManageBroadcast provides access to manage a channel’s
+	// broadcast configuration, including updating channel configuration and
+	// managing stream markers and stream tags.
+	ScopeChannelManageBroadcast = "channel:manage:broadcast"
+	// ScopeChannelManageExtensions provides access to manage a channel’s
+	// Extension configuration, including activating Extensions.
+	ScopeChannelManageExtensions = "channel:manage:extensions"
+	// ScopeChannelManagePolls provides access to manage a channel’s polls.
+	ScopeChannelManagePolls = "channel:manage:polls"
+	// ScopeChannelManagePredictions provides access to manage a channel’s
+	// Channel Points Predictions.
+	ScopeChannelManagePredictions = "channel:manage:predictions"
+	// ScopeChannelManageRedemptions provides access to manage Channel Points
+	// custom rewards and their redemptions on a channel.
+	ScopeChannelManageRedemptions = "channel:manage:redemptions"
+	// ScopeChannelManageSchedule provides access to manage a channel’s stream
+	// schedule.
+	ScopeChannelManageSchedule = "channel:manage:schedule"
+	// ScopeChannelManageVideos provides access to manage a channel’s videos,
+	// including deleting videos.
+	ScopeChannelManageVideos = "channel:manage:videos"
+	// ScopeChannelReadEditors provides access to view a list of users with the
+	// editor role for a channel.
+	ScopeChannelReadEditors = "channel:read:editors"
+	// ScopeChannelReadGoals provides access to view Creator Goals for a
+	// channel.
+	ScopeChannelReadGoals = "channel:read:goals"
+	// ScopeChannelReadHypeTrain provides access to view Hype Train information
+	// for a channel.
+	ScopeChannelReadHypeTrain = "channel:read:hype_train"
+	// ScopeChannelReadPolls provides access to view a channel’s polls.
+	ScopeChannelReadPolls = "channel:read:polls"
+	// ScopeChannelReadPredictions provides access to view a channel’s Channel
+	// Points Predictions.
+	ScopeChannelReadPredictions = "channel:read:predictions"
+	// ScopeChannelReadRedemptions provides access to view Channel Points custom
+	// rewards and their redemptions on a channel.
+	ScopeChannelReadRedemptions = "channel:read:redemptions"
+	// ScopeChannelReadStreamKey provides access to view an authorized user’s
+	// stream key.
+	ScopeChannelReadStreamKey = "channel:read:stream_key"
+	// ScopeChannelReadSubscriptions provides access to view a list of all
+	// subscribers to a channel and check if a user is subscribed to a channel.
+	ScopeChannelReadSubscriptions = "channel:read:subscriptions"
+	// ScopeClipsEdit provides access to manage Clips for a channel.
+	ScopeClipsEdit = "clips:edit"
+	// ScopeModerationRead provides access to view a channel’s moderation data
+	// including Moderators, Bans, Timeouts, and AutoMod settings.
+	ScopeModerationRead = "moderation:read"
+	// ScopeModeratorManageBannedUsers provides access to ban and unban users.
+	ScopeModeratorManageBannedUsers = "moderator:manage:banned_users"
+	// ScopeModeratorReadBlockedTerms provides access to view a broadcaster’s
+	// list of blocked terms.
+	ScopeModeratorReadBlockedTerms = "moderator:read:blocked_terms"
+	// ScopeModeratorManageBlockedTerms provides access to manage a
+	// broadcaster’s list of blocked terms.
+	ScopeModeratorManageBlockedTerms = "moderator:manage:blocked_terms"
+	// ScopeModeratorManageAutoMod provides access to manage messages held for
+	// review by AutoMod in channels where you are a moderator.
+	ScopeModeratorManageAutoMod = "moderator:manage:automod"
+	// ScopeModeratorReadAutoModSettings provides access to view a broadcaster’s
+	// AutoMod settings.
+	ScopeModeratorReadAutoModSettings = "moderator:read:automod_settings"
+	// ScopeModeratorManageAutoModSettings provides access to manage a
+	// broadcaster’s AutoMod settings.
+	ScopeModeratorManageAutoModSettings = "moderator:manage:automod_settings"
+	// ScopeModeratorReadChatSettings provides access to view a broadcaster’s
+	// chat room settings.
+	ScopeModeratorReadChatSettings = "moderator:read:chat_settings"
+	// ScopeModeratorManageChatSettings provides access to manage a
+	// broadcaster’s chat room settings.
+	ScopeModeratorManageChatSettings = "moderator:manage:chat_settings"
+	// ScopeUserEdit provides access to manage a user object.
+	ScopeUserEdit = "user:edit"
+	// ScopeUserEditFollows is deprecated. Was previously used for
+	// “Create User Follows” and “Delete User Follows.”
+	ScopeUserEditFollows = "user:edit:follows"
+	// ScopeUserManageBlockedUsers provides access to manage the block list of a
+	// user.
+	ScopeUserManageBlockedUsers = "user:manage:blocked_users"
+	// ScopeUserReadBlockedUsers provides access to view the block list of a
+	// user.
+	ScopeUserReadBlockedUsers = "user:read:blocked_users"
+	// ScopeUserReadBroadcast provides access to view a user’s broadcasting
+	// configuration, including Extension configurations.
+	ScopeUserReadBroadcast = "user:read:broadcast"
+	// ScopeUserReadEmail provides access to view a user’s email address.
+	ScopeUserReadEmail = "user:read:email"
+	// ScopeUserReadFollows provides access to view the list of channels a user
+	// follows.
+	ScopeUserReadFollows = "user:read:follows"
+	// ScopeUserReadSubscriptions provides access to view if an authorized user
+	// is subscribed to specific channels.
+	ScopeUserReadSubscriptions = "user:read:subscriptions"
+
+	// ScopeChannelSubscriptions is a v5 scope.
+	ScopeChannelSubscriptions = ScopeChannelReadSubscriptions
+	// ScopeChannelCommercial is a v5 scope.
+	ScopeChannelCommercial = ScopeChannelEditCommercial
+	// ScopeChannelEditor is a v5 scope which maps to channel:manage:broadcast
+	// and channel:manage:videos.
+	ScopeChannelEditor = "channel_editor"
+	// ScopeUserFollowsEdit is a v5 scope.
+	ScopeUserFollowsEdit = ScopeUserEditFollows
+	// ScopeChannelRead is a v5 scope which maps to channel:read:editors,
+	// channel:read:stream_key, and user:read:email.
+	ScopeChannelRead = "channel_read"
+	// ScopeUserRead is a v5 scope.
+	ScopeUserRead = ScopeUserReadEmail
+	// ScopeUserBlocksRead is a v5 scope.
+	ScopeUserBlocksRead = ScopeUserReadBlockedUsers
+	// ScopeUserBlocksEdit is a v5 scope.
+	ScopeUserBlocksEdit = ScopeUserManageBlockedUsers
+	// ScopeUserSubscriptions is a v5 scope.
+	ScopeUserSubscriptions = ScopeUserReadSubscriptions
 )
 
 // New creates a new Twitch provider, and sets up important connection details.
@@ -146,8 +221,8 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	if err != nil {
 		return user, err
 	}
+	req.Header.Set("Client-Id", p.config.ClientID)
 	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
-	req.Header.Set("Client-ID", p.config.ClientID)
 	resp, err := p.Client().Do(req)
 	if err != nil {
 		return user, err
@@ -163,33 +238,31 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 }
 
 func userFromReader(r io.Reader, user *goth.User) error {
-	u := struct {
+	var users struct {
 		Data []struct {
-			ID              string `json:"id"`
-			Login           string `json:"login"`
-			DisplayName     string `json:"display_name"`
-			Description     string `json:"description"`
-			ProfileImageURL string `json:"profile_image_url"`
-			Email           string `json:"email"`
+			ID          string `json:"id"`
+			Name        string `json:"login"`
+			Nickname    string `json:"display_name"`
+			Description string `json:"description"`
+			AvatarURL   string `json:"profile_image_url"`
+			Email       string `json:"email"`
 		} `json:"data"`
-	}{}
-
-	err := json.NewDecoder(r).Decode(&u)
+	}
+	err := json.NewDecoder(r).Decode(&users)
 	if err != nil {
 		return err
 	}
-
-	if len(u.Data) != 1 {
-		return fmt.Errorf("user not found in response")
+	if len(users.Data) == 0 {
+		return errors.New("user not found")
 	}
-
-	user.Name = u.Data[0].Login
-	user.Email = u.Data[0].Email
-	user.NickName = u.Data[0].DisplayName
+	u := users.Data[0]
+	user.Name = u.Name
+	user.Email = u.Email
+	user.NickName = u.Nickname
 	user.Location = "No location is provided by the Twitch API"
-	user.AvatarURL = u.Data[0].ProfileImageURL
-	user.Description = u.Data[0].Description
-	user.UserID = u.Data[0].ID
+	user.AvatarURL = u.AvatarURL
+	user.Description = u.Description
+	user.UserID = u.ID
 
 	return nil
 }
@@ -211,7 +284,7 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 			c.Scopes = append(c.Scopes, scope)
 		}
 	} else {
-		c.Scopes = []string{ScopeUserRead}
+		c.Scopes = []string{ScopeUserReadEmail}
 	}
 
 	return c


### PR DESCRIPTION
Applied minor stylistic changes to b8a528c and updated the authentication scopes per https://dev.twitch.tv/docs/authentication/#scopes and https://dev.twitch.tv/docs/api/migration#authentication-scopes. Authentication scopes no longer supported have been removed and those with equivalencies across the major versions have been appropriately mapped.

Notably `ScopeUserRead` which was the default scope applied now maps to `ScopeUserReadEmail` per the migration guide.