### PR TITLE
Use Bearer token in Slack

### DIFF
--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -119,7 +119,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	if p.hasScope(ScopeUserRead) {
 		// Get user profile info
-		req, _ := http.NewRequest("GET", endpointProfile+"&user="+user.UserID, nil)
+		req, _ := http.NewRequest("GET", endpointProfile+"?user="+user.UserID, nil)
 		req.Header.Add("Authorization", "Bearer "+sess.AccessToken)
 		response, err = p.Client().Do(req)
 		if err != nil {

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"fmt"
 
@@ -94,7 +93,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 
 	// Get the userID, slack needs userID in order to get user profile info
-	response, err := p.Client().Get(endpointUser + "?token=" + url.QueryEscape(sess.AccessToken))
+	req, _ := http.NewRequest("GET", endpointUser, nil)
+	req.Header.Add("Authorization", "Bearer "+sess.AccessToken)
+	response, err := p.Client().Do(req)
 	if err != nil {
 		return user, err
 	}

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -118,7 +118,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	if p.hasScope(ScopeUserRead) {
 		// Get user profile info
-		response, err = p.Client().Get(endpointProfile + "?token=" + url.QueryEscape(sess.AccessToken) + "&user=" + user.UserID)
+		req, _ := http.NewRequest("GET", endpointProfile+"&user="+user.UserID, nil)
+		req.Header.Add("Authorization", "Bearer "+sess.AccessToken)
+		response, err = p.Client().Do(req)
 		if err != nil {
 			return user, err
 		}


### PR DESCRIPTION
We found that the slack in goth does not get the userinfo correctly : https://github.com/casdoor/casdoor/issues/618 . After consulting the two api documents ([auth.test](https://api.slack.com/methods/auth.test), [users.info](https://api.slack.com/methods/users.info)), we found that currently the slack does not allow passing a token in the get parameter and has to use the body of the post to pass it or use the bearer token.

This pr modifies the slack request method and will now use the bearer token for the request.