### PR TITLE
Fix bug with pointer

### DIFF
--- a/providers/apple/session.go
+++ b/providers/apple/session.go
@@ -110,7 +110,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 			if !found {
 				return nil, errors.New("could not find matching public key")
 			}
-			var pubKey *rsa.PublicKey
+			pubKey := &rsa.PublicKey{}
 			err = selectedKey.Raw(pubKey)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Hi, in my previous PR https://github.com/markbates/goth/pull/453 I copy-pasted a bug with a nil pointer 🤦🏻‍♂️ . When we do `selectedKey.Raw(pubKey)` it then tries to evaluate the pointer with reflection but in our case the pointer is nil. So the app panics with error `panic: reflect: call of reflect.Value.Type on zero Value`:

```
panic: reflect: call of reflect.Value.Type on zero Value

goroutine 4 [running]:
	/usr/local/opt/go/libexec/src/runtime/panic.go:1038 +0x215
reflect.Value.Type({0x0, 0x0, 0xc0002e9898})
	/usr/local/opt/go/libexec/src/reflect/value.go:2262 +0x12e
github.com/lestrrat-go/blackmagic.AssignIfCompatible({0x1347140, 0x0}, {0x1347140, 0xc0002903f0})
	/Users/yaronius/Projects/goth/vendor/github.com/lestrrat-go/blackmagic/blackmagic.go:45 +0x296
github.com/lestrrat-go/jwx/jwk.(*rsaPublicKey).Raw(0xc0002827e0, {0x1347140, 0x0})
	/Users/yaronius/Projects/goth/vendor/github.com/lestrrat-go/jwx/jwk/rsa.go:172 +0x239
github.com/markbates/goth/providers/apple.(*Session).Authorize.func1(0xc0000a0140)
	/Users/yaronius/Projects/goth/providers/apple/session.go:120 +0x496
github.com/golang-jwt/jwt/v4.(*Parser).ParseWithClaims(0xc00009c2a0, {0xc0000fae00, 0xc00011bc30}, {0x141a600, 0xc0000b0750}, 0xc00011bcb8)
	/Users/yaronius/Projects/goth/vendor/github.com/golang-jwt/jwt/v4/parser.go:73 +0xf8
github.com/golang-jwt/jwt/v4.ParseWithClaims({0xc0000fae00, 0x30e}, {0x141a600, 0xc0000b0750}, 0x5, {0x0, 0x2, 0x100e374})
	/Users/yaronius/Projects/goth/vendor/github.com/golang-jwt/jwt/v4/token.go:107 +0x65
github.com/markbates/goth/providers/apple.(*Session).Authorize(0xc000140630, {0x14281e8, 0xc00010c600}, {0x141b7c0, 0xc0002842d0})
	/Users/yaronius/Projects/goth/providers/apple/session.go:78 +0x36b
```
This small fix should solve the issue.
It would also be nice to write some tests for this problem but I'm not sure how to do it properly.