### PR TITLE
Update Example to include TwitterV2, fix TwitterV2 crash

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/markbates/goth/providers/tiktok"
 	"github.com/markbates/goth/providers/twitch"
 	"github.com/markbates/goth/providers/twitter"
+	"github.com/markbates/goth/providers/twitterv2"
 	"github.com/markbates/goth/providers/typetalk"
 	"github.com/markbates/goth/providers/uber"
 	"github.com/markbates/goth/providers/vk"
@@ -73,6 +74,12 @@ import (
 
 func main() {
 	goth.UseProviders(
+		// Use twitterv2 instead of twitter if you only have access to the Essential API Level
+		// the twitter provider uses a v1.1 API that is not available to the Essential Level
+		twitterv2.New(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitterv2/callback"),
+		// If you'd like to use authenticate instead of authorize in TwitterV2 provider, use this instead.
+		// twitterv2.NewAuthenticate(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitterv2/callback"),
+
 		twitter.New(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
 		// If you'd like to use authenticate instead of authorize in Twitter provider, use this instead.
 		// twitter.NewAuthenticate(os.Getenv("TWITTER_KEY"), os.Getenv("TWITTER_SECRET"), "http://localhost:3000/auth/twitter/callback"),
@@ -191,6 +198,7 @@ func main() {
 	m["battlenet"] = "Battlenet"
 	m["paypal"] = "Paypal"
 	m["twitter"] = "Twitter"
+	m["twitterv2"] = "Twitter"
 	m["salesforce"] = "Salesforce"
 	m["typetalk"] = "Typetalk"
 	m["slack"] = "Slack"

--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -108,7 +108,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	response, err := p.consumer.Get(
 		endpointProfile,
-		nil,
+		map[string]string{"user.fields": "id,name,username,description,profile_image_url,location"},
 		sess.AccessToken)
 	if err != nil {
 		return user, err
@@ -136,13 +136,12 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user.RawData = userInfo.Data
 	user.Name = user.RawData["name"].(string)
 	user.NickName = user.RawData["username"].(string)
-	if user.RawData["email"] != nil {
-		user.Email = user.RawData["email"].(string)
-	}
 	user.Description = user.RawData["description"].(string)
 	user.AvatarURL = user.RawData["profile_image_url"].(string)
 	user.UserID = user.RawData["id"].(string)
-	user.Location = user.RawData["location"].(string)
+	if user.RawData["location"] != nil {
+		user.Location = user.RawData["location"].(string)
+	}
 	user.AccessToken = sess.AccessToken.Token
 	user.AccessTokenSecret = sess.AccessToken.Secret
 	return user, err
@@ -162,12 +161,12 @@ func newConsumer(provider *Provider, authURL string) *oauth.Consumer {
 	return c
 }
 
-//RefreshToken refresh token is not provided by twitter
+// RefreshToken refresh token is not provided by twitter
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	return nil, errors.New("Refresh token is not provided by twitter")
 }
 
-//RefreshTokenAvailable refresh token is not provided by twitter
+// RefreshTokenAvailable refresh token is not provided by twitter
 func (p *Provider) RefreshTokenAvailable() bool {
 	return false
 }

--- a/providers/twitterv2/twitterv2_test.go
+++ b/providers/twitterv2/twitterv2_test.go
@@ -69,7 +69,7 @@ func Test_FetchUser(t *testing.T) {
 	a.Equal("1234", user.UserID)
 	a.Equal("Springfield", user.Location)
 	a.Equal("TOKEN", user.AccessToken)
-	a.Equal("duffman@springfield.com", user.Email)
+	a.Equal("", user.Email)
 }
 
 func Test_SessionFromJSON(t *testing.T) {


### PR DESCRIPTION
Add TwitterV2 Provider to the example, the Twitter provider does not work if you only have the Essentail API Access Level because it uses the v1.1 API to get userInfo(see [Twitter API Docs](https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api))

Changes to TwitterV2 Provider per [Twitter API Docs](https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me)

- Add Response fields, only id,name,username are default. Added description,profile_image_url,location
- Remove E-Mail check/cast because the v2 API user info API does not contain the E-Mail
- Add check for location because it can be nil if the user did not set a location