### PR TITLE
fix(discord): prompt only if permissions have changed

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -5,14 +5,13 @@ package discord
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/markbates/goth"
 	"golang.org/x/oauth2"
-
-	"fmt"
-	"net/http"
 )
 
 const (
@@ -85,8 +84,11 @@ func (p *Provider) Debug(debug bool) {}
 
 // BeginAuth asks Discord for an authentication end-point.
 func (p *Provider) BeginAuth(state string) (goth.Session, error) {
-
-	url := p.config.AuthCodeURL(state, oauth2.AccessTypeOnline)
+	url := p.config.AuthCodeURL(
+		state,
+		oauth2.AccessTypeOnline,
+		oauth2.SetAuthURLParam("prompt", "none"),
+	)
 
 	s := &Session{
 		AuthURL: url,
@@ -96,7 +98,6 @@ func (p *Provider) BeginAuth(state string) (goth.Session, error) {
 
 // FetchUser will go to Discord and access basic info about the user.
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
-
 	s := session.(*Session)
 
 	user := goth.User{
@@ -164,9 +165,9 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		return err
 	}
 
-	//If this prefix is present, the image should be available as a gif,
-	//See : https://discord.com/developers/docs/reference#image-formatting
-	//Introduced by : Yyewolf
+	// If this prefix is present, the image should be available as a gif,
+	// See : https://discord.com/developers/docs/reference#image-formatting
+	// Introduced by : Yyewolf
 
 	if u.AvatarID != "" {
 		avatarExtension := ".jpg"
@@ -207,12 +208,12 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 	return c
 }
 
-//RefreshTokenAvailable refresh token is provided by auth provider or not
+// RefreshTokenAvailable refresh token is provided by auth provider or not
 func (p *Provider) RefreshTokenAvailable() bool {
 	return true
 }
 
-//RefreshToken get new access token based on the refresh token
+// RefreshToken get new access token based on the refresh token
 func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	token := &oauth2.Token{RefreshToken: refreshToken}
 	ts := p.config.TokenSource(oauth2.NoContext, token)


### PR DESCRIPTION
The current Discord oauth2 flow does not provide a `prompt` GET parameter during the redirect to Discord. As such, the default flow for Discord is to always prompt to validate the flow, even if the user has **already previously approved the provided scopes**. This PR ensures that `prompt=none` is provided, so Discord will only require a re-prompt if permissions have changed, or if there are elevated permissions being requested.

> `prompt` controls how the authorization flow handles existing authorizations. If a user has previously authorized your application with the requested scopes and prompt is set to `consent`, it will request them to reapprove their authorization. If set to `none`, it will skip the authorization screen and redirect them back to your redirect URI without requesting their authorization. For passthrough scopes, like `bot` and `webhook.incoming`, authorization is always required.

I.e:

- If scopes haven't been previously approved, prompt.
- If sensitive scopes (`bot` & `webhook.incoming`) are used, ignore `prompt` parameter, and provide consent dialog.
- If all scopes have already been approved previously, auto-redirect back to application.

Should be a non-breaking change.

- closes #401