### PR TITLE
Add nil check for twitter description field

### DIFF
--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -138,7 +138,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user.NickName = user.RawData["username"].(string)
 	if user.RawData["description"] != nil {
 		user.Description = user.RawData["description"].(string)
-	}	
+	}
 	user.AvatarURL = user.RawData["profile_image_url"].(string)
 	user.UserID = user.RawData["id"].(string)
 	if user.RawData["location"] != nil {

--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -136,7 +136,9 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	user.RawData = userInfo.Data
 	user.Name = user.RawData["name"].(string)
 	user.NickName = user.RawData["username"].(string)
-	user.Description = user.RawData["description"].(string)
+	if user.RawData["description"] != nil {
+		user.Description = user.RawData["description"].(string)
+	}	
 	user.AvatarURL = user.RawData["profile_image_url"].(string)
 	user.UserID = user.RawData["id"].(string)
 	if user.RawData["location"] != nil {


### PR DESCRIPTION
Add a nil check for twitter description field. When executing FetchUser an interface conversion error is thrown when parsing the description field. This PR fixes that occurrence.

```
2022/09/18 23:55:28 http: panic serving [::1]:49881: interface conversion: interface {} is nil, not string
goroutine 9 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1825 +0xb0
panic({0x100ba35a0, 0x140004196e0})
        /usr/local/go/src/runtime/panic.go:844 +0x258
github.com/markbates/goth/providers/twitterv2.(*Provider).FetchUser(_, {_, _})
        /Users/omer/go/pkg/mod/github.com/markbates/goth@v1.73.0/providers/twitterv2/twitterv2.go:142 +0x6c4
github.com/markbates/goth/gothic.glob..func3({_, _}, _)
        /Users/omer/go/pkg/mod/github.com/markbates/goth@v1.73.0/gothic/gothic.go:215 +0x3cc
example.com/web.SocialEndpoints.func1({0x100c5d9c0?, 0x140001781c0}, 0x14000468000?, {0x3?, 0x14000178200?, 0x0?})
        /Users/omer/Code/example/web/social.go:215 +0x58
github.com/julienschmidt/httprouter.(*Router).ServeHTTP(0x140000b0b40, {0x100c5d9c0, 0x140001781c0}, 0x14000602000)
        /Users/omer/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387 +0x744
net/http.serverHandler.ServeHTTP({0x140003510e0?}, {0x100c5d9c0, 0x140001781c0}, 0x14000602000)
        /usr/local/go/src/net/http/server.go:2916 +0x3fc
net/http.(*conn).serve(0x140002670e0, {0x100c5e278, 0x14000350ff0})
        /usr/local/go/src/net/http/server.go:1966 +0x56c
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:3071 +0x450

```