### PR TITLE
openidconnect: allow overriding redirect_uri and passing code_verifier

### DIFF
--- a/providers/openidConnect/session.go
+++ b/providers/openidConnect/session.go
@@ -3,10 +3,11 @@ package openidConnect
 import (
 	"encoding/json"
 	"errors"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"strings"
 	"time"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 // Session stores data during the auth process with the OpenID Connect provider.
@@ -29,7 +30,22 @@ func (s Session) GetAuthURL() (string, error) {
 // Authorize the session with the OpenID Connect provider and return the access token to be stored for future use.
 func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	p := provider.(*Provider)
-	token, err := p.config.Exchange(oauth2.NoContext, params.Get("code"))
+
+	var authParams []oauth2.AuthCodeOption
+
+	// override redirect_uri if passed as param
+	redirectURL := params.Get("redirect_uri")
+	if redirectURL != "" {
+		authParams = append(authParams, oauth2.SetAuthURLParam("redirect_uri", redirectURL))
+	}
+
+	// set code_verifier if passed as param
+	codeVerifier := params.Get("code_verifier")
+	if codeVerifier != "" {
+		authParams = append(authParams, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
+	}
+
+	token, err := p.config.Exchange(goth.ContextForClient(p.Client()), params.Get("code"), authParams...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Similar to #459 this PR extends openidconnect provider's `Session.Authorize` to allow passage of `redirect_uri` and `code_verifier` params.

Gitea will need these in order to enable support for PKCE in openidconnect. (See https://github.com/go-gitea/gitea/issues/21376)

It is likely that other providers will also need the addition of PKCE support however, the design of this may need some more thought.

Fix #473

Signed-off-by: Andrew Thornton <art27@cantab.net>