### PR TITLE
feat/azureadv2: retrieve ID token from response if available

### DIFF
--- a/providers/azureadv2/azureadv2.go
+++ b/providers/azureadv2/azureadv2.go
@@ -159,6 +159,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	err = userFromReader(response.Body, &user)
 	user.AccessToken = msSession.AccessToken
+	user.IDToken = msSession.IDToken
 	user.RefreshToken = msSession.RefreshToken
 	user.ExpiresAt = msSession.ExpiresAt
 	return user, err

--- a/providers/azureadv2/session.go
+++ b/providers/azureadv2/session.go
@@ -13,6 +13,7 @@ import (
 type Session struct {
 	AuthURL      string    `json:"au"`
 	AccessToken  string    `json:"at"`
+	IDToken      string    `json:"it"`
 	RefreshToken string    `json:"rt"`
 	ExpiresAt    time.Time `json:"exp"`
 }
@@ -41,6 +42,9 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	s.AccessToken = token.AccessToken
 	s.RefreshToken = token.RefreshToken
 	s.ExpiresAt = token.Expiry
+	if idTok, ok := token.Extra("id_token").(string); ok {
+		s.IDToken = idTok
+	}
 
 	return token.AccessToken, err
 }

--- a/providers/azureadv2/session_test.go
+++ b/providers/azureadv2/session_test.go
@@ -36,7 +36,7 @@ func Test_ToJSON(t *testing.T) {
 	s := &azureadv2.Session{}
 
 	data := s.Marshal()
-	a.Equal(`{"au":"","at":"","rt":"","exp":"0001-01-01T00:00:00Z"}`, data)
+	a.Equal(`{"au":"","at":"","it":"","rt":"","exp":"0001-01-01T00:00:00Z"}`, data)
 }
 
 func Test_String(t *testing.T) {


### PR DESCRIPTION
Currently the Azure AD v2 provider gets back the access token and ID token in its response when exchanging the authorization code, but it ignores the ID token. This PR retrieves the ID token from the response and passes it back through to the API consumer via the return `User`.