### PR TITLE
Attempted fix for #483

### DIFF
--- a/providers/mastodon/mastodon.go
+++ b/providers/mastodon/mastodon.go
@@ -153,6 +153,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		NickName  string `json:"username"`
 		ID        string `json:"id"`
 		AvatarURL string `json:"avatar"`
+		Email     string `json:"fqn"`
 	}{}
 	err := json.NewDecoder(r).Decode(&u)
 	if err != nil {
@@ -165,6 +166,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.NickName = u.NickName
 	user.UserID = u.ID
 	user.AvatarURL = u.AvatarURL
+	user.Email = u.Email
 	return nil
 }
 


### PR DESCRIPTION
I have attempted to use the strategies from the discord oauth (which has email handing) for mastodon, to provide the oauth client a usable email in the form of the user fqn (user@instance.tld) which should allow gitea to create user accounts through oauth, please correct if needed, but I think this might work.