### PR TITLE
Password grant flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ go get github.com/markbates/goth
 * OpenID Connect (auto discovery)
 * Oura
 * Patreon
+* Password Grant
 * Paypal
 * SalesForce
 * Shopify

--- a/examples/main.go
+++ b/examples/main.go
@@ -163,7 +163,6 @@ func main() {
 
 	directProvider := direct.New("/login")
 	directProvider.FetchUserByToken = func(token string) (goth.User, error) {
-		log.Println("fetching user by token:", token)
 		return goth.User{
 			Email:       "john@doe.com",
 			FirstName:   "John",
@@ -175,7 +174,6 @@ func main() {
 		}, nil
 	}
 	directProvider.CredChecker = func(email, password string) error {
-		log.Println("checking credentials:", email, password)
 		if email == "john@doe.com" && password == "password" {
 			return nil
 		}

--- a/examples/main.go
+++ b/examples/main.go
@@ -332,9 +332,13 @@ var loginTemplate = `
 `
 
 var indexTemplate = `
+<html>
+<body>
 {{range $key,$value:=.Providers}}
     <p><a href="/auth/{{$value}}">Log in with {{index $.ProvidersMap $value}}</a></p>
 {{end}}
+</body>
+</html>
 `
 
 var userTemplate = `

--- a/examples/main.go
+++ b/examples/main.go
@@ -161,8 +161,7 @@ func main() {
 		goth.UseProviders(openidConnect)
 	}
 
-	directProvider := direct.New("/login")
-	directProvider.UserFetcher = func(email string) (goth.User, error) {
+	var userFetcher = func(email string) (goth.User, error) {
 		if email != "john@doe.com" {
 			return goth.User{}, errors.New("user not found")
 		}
@@ -177,12 +176,13 @@ func main() {
 			Provider:  "direct",
 		}, nil
 	}
-	directProvider.CredChecker = func(email, password string) error {
+	var credChecker = func(email, password string) error {
 		if email == "john@doe.com" && password == "password" {
 			return nil
 		}
 		return errors.New("invalid username or password")
 	}
+	directProvider := direct.New("/login", userFetcher, credChecker)
 	goth.UseProviders(directProvider)
 
 	m := map[string]string{

--- a/examples/main.go
+++ b/examples/main.go
@@ -92,7 +92,7 @@ func main() {
 		fitbit.New(os.Getenv("FITBIT_KEY"), os.Getenv("FITBIT_SECRET"), "http://localhost:3000/auth/fitbit/callback"),
 		google.New(os.Getenv("GOOGLE_KEY"), os.Getenv("GOOGLE_SECRET"), "http://localhost:3000/auth/google/callback"),
 		gplus.New(os.Getenv("GPLUS_KEY"), os.Getenv("GPLUS_SECRET"), "http://localhost:3000/auth/gplus/callback"),
-		github.New(os.Getenv("GITHUB_ID"), os.Getenv("GITHUB_SECRET"), "http://localhost:3000/auth/github/callback"),
+		github.New(os.Getenv("GITHUB_KEY"), os.Getenv("GITHUB_SECRET"), "http://localhost:3000/auth/github/callback"),
 		spotify.New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "http://localhost:3000/auth/spotify/callback"),
 		linkedin.New(os.Getenv("LINKEDIN_KEY"), os.Getenv("LINKEDIN_SECRET"), "http://localhost:3000/auth/linkedin/callback"),
 		line.New(os.Getenv("LINE_KEY"), os.Getenv("LINE_SECRET"), "http://localhost:3000/auth/line/callback", "profile", "openid", "email"),

--- a/examples/main.go
+++ b/examples/main.go
@@ -92,7 +92,7 @@ func main() {
 		fitbit.New(os.Getenv("FITBIT_KEY"), os.Getenv("FITBIT_SECRET"), "http://localhost:3000/auth/fitbit/callback"),
 		google.New(os.Getenv("GOOGLE_KEY"), os.Getenv("GOOGLE_SECRET"), "http://localhost:3000/auth/google/callback"),
 		gplus.New(os.Getenv("GPLUS_KEY"), os.Getenv("GPLUS_SECRET"), "http://localhost:3000/auth/gplus/callback"),
-		github.New("226a00177637d271c02b", "47abea8888fd34cc86fe2269341ebe44410ef700", "http://localhost:3000/auth/github/callback"),
+		github.New(os.Getenv("GITHUD_ID"), os.Getenv("GITHUB_SECRET"), "http://localhost:3000/auth/github/callback"),
 		spotify.New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "http://localhost:3000/auth/spotify/callback"),
 		linkedin.New(os.Getenv("LINKEDIN_KEY"), os.Getenv("LINKEDIN_SECRET"), "http://localhost:3000/auth/linkedin/callback"),
 		line.New(os.Getenv("LINE_KEY"), os.Getenv("LINE_SECRET"), "http://localhost:3000/auth/line/callback", "profile", "openid", "email"),
@@ -162,7 +162,12 @@ func main() {
 	}
 
 	directProvider := direct.New("/login")
-	directProvider.FetchUserByToken = func(token string) (goth.User, error) {
+	directProvider.UserFetcher = func(email, token string) (goth.User, error) {
+		if email != "john@doe.com" {
+			return goth.User{}, errors.New("user not found")
+		}
+
+		// Possible to associate the token with the user
 		return goth.User{
 			Email:       "john@doe.com",
 			FirstName:   "John",
@@ -170,7 +175,7 @@ func main() {
 			NickName:    "JD",
 			UserID:      "123456789",
 			Provider:    "direct",
-			AccessToken: "123456789",
+			AccessToken: token,
 		}, nil
 	}
 	directProvider.CredChecker = func(email, password string) error {

--- a/examples/main.go
+++ b/examples/main.go
@@ -92,7 +92,7 @@ func main() {
 		fitbit.New(os.Getenv("FITBIT_KEY"), os.Getenv("FITBIT_SECRET"), "http://localhost:3000/auth/fitbit/callback"),
 		google.New(os.Getenv("GOOGLE_KEY"), os.Getenv("GOOGLE_SECRET"), "http://localhost:3000/auth/google/callback"),
 		gplus.New(os.Getenv("GPLUS_KEY"), os.Getenv("GPLUS_SECRET"), "http://localhost:3000/auth/gplus/callback"),
-		github.New(os.Getenv("GITHUD_ID"), os.Getenv("GITHUB_SECRET"), "http://localhost:3000/auth/github/callback"),
+		github.New(os.Getenv("GITHUB_ID"), os.Getenv("GITHUB_SECRET"), "http://localhost:3000/auth/github/callback"),
 		spotify.New(os.Getenv("SPOTIFY_KEY"), os.Getenv("SPOTIFY_SECRET"), "http://localhost:3000/auth/spotify/callback"),
 		linkedin.New(os.Getenv("LINKEDIN_KEY"), os.Getenv("LINKEDIN_SECRET"), "http://localhost:3000/auth/linkedin/callback"),
 		line.New(os.Getenv("LINE_KEY"), os.Getenv("LINE_SECRET"), "http://localhost:3000/auth/line/callback", "profile", "openid", "email"),
@@ -162,20 +162,19 @@ func main() {
 	}
 
 	directProvider := direct.New("/login")
-	directProvider.UserFetcher = func(email, token string) (goth.User, error) {
+	directProvider.UserFetcher = func(email string) (goth.User, error) {
 		if email != "john@doe.com" {
 			return goth.User{}, errors.New("user not found")
 		}
 
 		// Possible to associate the token with the user
 		return goth.User{
-			Email:       "john@doe.com",
-			FirstName:   "John",
-			LastName:    "Doe",
-			NickName:    "JD",
-			UserID:      "123456789",
-			Provider:    "direct",
-			AccessToken: token,
+			Email:     "john@doe.com",
+			FirstName: "John",
+			LastName:  "Doe",
+			NickName:  "JD",
+			UserID:    "123456789",
+			Provider:  "direct",
 		}, nil
 	}
 	directProvider.CredChecker = func(email, password string) error {

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -217,7 +217,7 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 }
 
 // PasswordGrantAuth is a helper function that make sure
-// authetication is done with the "direct" provider
+// authentication happens via the "direct" provider
 func PasswordGrantAuth(res http.ResponseWriter, req *http.Request) (goth.User, error) {
 	ctx := req.Context()
 	ctx = context.WithValue(ctx, ProviderParamKey, "direct")

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -216,6 +216,16 @@ var CompleteUserAuth = func(res http.ResponseWriter, req *http.Request) (goth.Us
 	return gu, err
 }
 
+// PasswordGrantAuth is a helper function that make sure
+// authetication is done with the "direct" provider
+func PasswordGrantAuth(res http.ResponseWriter, req *http.Request) (goth.User, error) {
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, ProviderParamKey, "direct")
+	req = req.WithContext(ctx)
+
+	return CompleteUserAuth(res, req)
+}
+
 // validateState ensures that the state token param from the original
 // AuthURL matches the one included in the current (callback) request.
 func validateState(req *http.Request, sess goth.Session) error {

--- a/providers/direct/direct.go
+++ b/providers/direct/direct.go
@@ -13,7 +13,6 @@ import (
 
 type AccessTokenGenerator func() string
 
-// Non puo funzionare con token
 type UserFetcher func(email string) (goth.User, error)
 
 type CredChecker func(email, password string) error
@@ -33,11 +32,13 @@ func DefaultTokenGenerator() string {
 	return fmt.Sprintf("%x", b)
 }
 
-func New(authUrl string) *Provider {
+func New(authUrl string, userFetcher UserFetcher, credChecker CredChecker) *Provider {
 	return &Provider{
 		name:                 "direct",
 		AccessTokenGenerator: DefaultTokenGenerator,
 		AuthURL:              authUrl,
+		UserFetcher:          userFetcher,
+		CredChecker:          credChecker,
 	}
 }
 

--- a/providers/direct/direct.go
+++ b/providers/direct/direct.go
@@ -14,7 +14,7 @@ import (
 type AccessTokenGenerator func() string
 
 // Non puo funzionare con token
-type UserFetcher func(email, token string) (goth.User, error)
+type UserFetcher func(email string) (goth.User, error)
 
 type CredChecker func(email, password string) error
 
@@ -64,12 +64,12 @@ func (p *Provider) UnmarshalSession(data string) (goth.Session, error) {
 func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	directSession := session.(*Session)
 
-	if directSession.AccessToken == "" {
+	if directSession.Email == "" {
 		// data is not yet retrieved since accessToken is still empty
 		return goth.User{}, fmt.Errorf("%s cannot get user information without accessToken", p.name)
 	}
 
-	user, err := p.UserFetcher(directSession.Email, directSession.AccessToken)
+	user, err := p.UserFetcher(directSession.Email)
 	if err != nil {
 		return goth.User{}, err
 	}
@@ -94,9 +94,7 @@ func (p *Provider) IssueSession(email, password string) (goth.Session, error) {
 		return nil, errors.New("invalid username or password")
 	}
 
-	accessToken := p.AccessTokenGenerator()
 	return &Session{
-		AccessToken: accessToken,
-		Email:       email,
+		Email: email,
 	}, nil
 }

--- a/providers/direct/direct.go
+++ b/providers/direct/direct.go
@@ -14,7 +14,7 @@ import (
 type AccessTokenGenerator func() string
 
 // Non puo funzionare con token
-type FetchUserByToken func(token string) (goth.User, error)
+type UserFetcher func(email, token string) (goth.User, error)
 
 type CredChecker func(email, password string) error
 
@@ -22,7 +22,7 @@ type Provider struct {
 	name    string
 	debug   bool
 	AuthURL string
-	FetchUserByToken
+	UserFetcher
 	CredChecker
 	AccessTokenGenerator
 }
@@ -69,7 +69,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return goth.User{}, fmt.Errorf("%s cannot get user information without accessToken", p.name)
 	}
 
-	user, err := p.FetchUserByToken(directSession.AccessToken)
+	user, err := p.UserFetcher(directSession.Email, directSession.AccessToken)
 	if err != nil {
 		return goth.User{}, err
 	}

--- a/providers/direct/direct.go
+++ b/providers/direct/direct.go
@@ -1,0 +1,101 @@
+package direct
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
+)
+
+type AccessTokenGenerator func() string
+
+type FetchUserByToken func(token string) (goth.User, error)
+
+type CredChecker func(email, password string) error
+
+type DirectProvider struct {
+	name    string
+	debug   bool
+	AuthURL string
+	FetchUserByToken
+	CredChecker
+	AccessTokenGenerator
+}
+
+func DefaultTokenGenerator() string {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+func New(authUrl string) *DirectProvider {
+	return &DirectProvider{
+		name:                 "direct",
+		AccessTokenGenerator: DefaultTokenGenerator,
+		AuthURL:              authUrl,
+	}
+}
+
+func (p *DirectProvider) Name() string {
+	return p.name
+}
+
+func (p *DirectProvider) SetName(name string) {
+	p.name = name
+}
+
+func (p *DirectProvider) BeginAuth(state string) (goth.Session, error) {
+	return &DirectSession{
+		AuthURL: p.AuthURL,
+	}, nil
+}
+
+func (p *DirectProvider) UnmarshalSession(data string) (goth.Session, error) {
+	sess := &DirectSession{}
+	err := json.NewDecoder(strings.NewReader(data)).Decode(sess)
+	return sess, err
+}
+
+func (p *DirectProvider) FetchUser(session goth.Session) (goth.User, error) {
+	directSession := session.(*DirectSession)
+
+	if directSession.AccessToken == "" {
+		// data is not yet retrieved since accessToken is still empty
+		return goth.User{}, fmt.Errorf("%s cannot get user information without accessToken", p.name)
+	}
+
+	user, err := p.FetchUserByToken(directSession.AccessToken)
+	if err != nil {
+		return goth.User{}, err
+	}
+
+	return user, nil
+}
+
+func (p *DirectProvider) Debug(debug bool) {
+	p.debug = debug
+}
+
+func (p *DirectProvider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
+	return nil, errors.New("refreshToken not supported for the password grant")
+}
+
+func (p *DirectProvider) RefreshTokenAvailable() bool {
+	return false
+}
+
+func (p *DirectProvider) IssueSession(email, password string) (goth.Session, error) {
+	if p.CredChecker(email, password) != nil {
+		return nil, errors.New("invalid username or password")
+	}
+
+	accessToken := p.AccessTokenGenerator()
+	return &DirectSession{
+		AccessToken: accessToken,
+		Email:       email,
+	}, nil
+}

--- a/providers/direct/direct.go
+++ b/providers/direct/direct.go
@@ -1,7 +1,6 @@
 package direct
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,19 +25,12 @@ type Provider struct {
 	AccessTokenGenerator
 }
 
-func DefaultTokenGenerator() string {
-	b := make([]byte, 32)
-	_, _ = rand.Read(b)
-	return fmt.Sprintf("%x", b)
-}
-
 func New(authUrl string, userFetcher UserFetcher, credChecker CredChecker) *Provider {
 	return &Provider{
-		name:                 "direct",
-		AccessTokenGenerator: DefaultTokenGenerator,
-		AuthURL:              authUrl,
-		UserFetcher:          userFetcher,
-		CredChecker:          credChecker,
+		name:        "direct",
+		AuthURL:     authUrl,
+		UserFetcher: userFetcher,
+		CredChecker: credChecker,
 	}
 }
 
@@ -66,7 +58,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	directSession := session.(*Session)
 
 	if directSession.Email == "" {
-		// data is not yet retrieved since accessToken is still empty
+		// data is not yet retrieved since email is still empty
 		return goth.User{}, fmt.Errorf("%s cannot get user information without accessToken", p.name)
 	}
 

--- a/providers/direct/direct_test.go
+++ b/providers/direct/direct_test.go
@@ -80,7 +80,6 @@ func TestDirectProvider(t *testing.T) {
 			t.Errorf("expected no error, got %v", err)
 		}
 
-		// Check if the unmarshalled session is the same as the original session
 		if session.Marshal() != unmarshalledSession.Marshal() {
 			t.Error("unmarshalled session data does not match the original session data")
 		}

--- a/providers/direct/direct_test.go
+++ b/providers/direct/direct_test.go
@@ -12,16 +12,12 @@ func TestDirectProvider(t *testing.T) {
 	p := direct.New("/login")
 
 	users := map[string]goth.User{
-		"123": {
+		"test@example.com": {
 			Email: "test@example.com",
 		},
 	}
-
-	p.AccessTokenGenerator = func() string {
-		return "123"
-	}
-	p.FetchUserByToken = func(token string) (goth.User, error) {
-		if user, ok := users[token]; ok {
+	p.UserFetcher = func(email, token string) (goth.User, error) {
+		if user, ok := users[email]; ok {
 			return user, nil
 		}
 		return goth.User{}, errors.New("user not found")

--- a/providers/direct/direct_test.go
+++ b/providers/direct/direct_test.go
@@ -1,0 +1,92 @@
+package direct_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/direct"
+)
+
+func TestDirectProvider(t *testing.T) {
+	p := direct.New("/login")
+
+	users := map[string]goth.User{
+		"123": {
+			Email: "test@example.com",
+		},
+	}
+
+	p.AccessTokenGenerator = func() string {
+		return "123"
+	}
+	p.FetchUserByToken = func(token string) (goth.User, error) {
+		if user, ok := users[token]; ok {
+			return user, nil
+		}
+		return goth.User{}, errors.New("user not found")
+	}
+	p.CredChecker = func(email, password string) error {
+		if email == "test@example.com" && password == "password" {
+			return nil
+		}
+		return errors.New("invalid email or password")
+	}
+
+	t.Run("Name", func(t *testing.T) {
+		if p.Name() != "direct" {
+			t.Errorf("expected provider name to be 'direct', got %s", p.Name())
+		}
+	})
+
+	t.Run("SetName", func(t *testing.T) {
+		p.SetName("direct_custom")
+		if p.Name() != "direct_custom" {
+			t.Errorf("expected provider name to be 'direct_custom', got %s", p.Name())
+		}
+	})
+
+	t.Run("IssueSession", func(t *testing.T) {
+		_, err := p.IssueSession("test@example.com", "password")
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		_, err = p.IssueSession("test@example.com", "wrong_password")
+		if err == nil {
+			t.Error("expected error for invalid password, got nil")
+		}
+
+		_, err = p.IssueSession("nonexistent@example.com", "password")
+		if err == nil {
+			t.Error("expected error for non-existent user, got nil")
+		}
+	})
+
+	t.Run("FetchUser", func(t *testing.T) {
+		session, _ := p.IssueSession("test@example.com", "password")
+
+		user, err := p.FetchUser(session)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if user.Email != "test@example.com" {
+			t.Errorf("expected email to be 'test@example.com', got %s", user.Email)
+		}
+	})
+
+	t.Run("UnmarshalSession", func(t *testing.T) {
+		session, _ := p.IssueSession("test@example.com", "password")
+		data := session.Marshal()
+
+		unmarshalledSession, err := p.UnmarshalSession(data)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// Check if the unmarshalled session is the same as the original session
+		if session.Marshal() != unmarshalledSession.Marshal() {
+			t.Error("unmarshalled session data does not match the original session data")
+		}
+	})
+}

--- a/providers/direct/direct_test.go
+++ b/providers/direct/direct_test.go
@@ -16,7 +16,7 @@ func TestDirectProvider(t *testing.T) {
 			Email: "test@example.com",
 		},
 	}
-	p.UserFetcher = func(email, token string) (goth.User, error) {
+	p.UserFetcher = func(email string) (goth.User, error) {
 		if user, ok := users[email]; ok {
 			return user, nil
 		}

--- a/providers/direct/direct_test.go
+++ b/providers/direct/direct_test.go
@@ -9,25 +9,25 @@ import (
 )
 
 func TestDirectProvider(t *testing.T) {
-	p := direct.New("/login")
-
 	users := map[string]goth.User{
 		"test@example.com": {
 			Email: "test@example.com",
 		},
 	}
-	p.UserFetcher = func(email string) (goth.User, error) {
+
+	var userFetcher = func(email string) (goth.User, error) {
 		if user, ok := users[email]; ok {
 			return user, nil
 		}
 		return goth.User{}, errors.New("user not found")
 	}
-	p.CredChecker = func(email, password string) error {
+	var credChecker = func(email, password string) error {
 		if email == "test@example.com" && password == "password" {
 			return nil
 		}
 		return errors.New("invalid email or password")
 	}
+	p := direct.New("/login", userFetcher, credChecker)
 
 	t.Run("Name", func(t *testing.T) {
 		if p.Name() != "direct" {

--- a/providers/direct/session.go
+++ b/providers/direct/session.go
@@ -41,6 +41,6 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}
 
 	s.Email = sess.Email
-	// Result of Authorize is not used by gothic
+	// Result of Authorize is not used by gothic package
 	return "", nil
 }

--- a/providers/direct/session.go
+++ b/providers/direct/session.go
@@ -8,9 +8,8 @@ import (
 )
 
 type Session struct {
-	AuthURL     string
-	AccessToken string
-	Email       string
+	AuthURL string
+	Email   string
 }
 
 func (s *Session) GetAuthURL() (string, error) {
@@ -41,7 +40,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", errors.New("invalid session type")
 	}
 
-	s.AccessToken = sess.AccessToken
 	s.Email = sess.Email
-	return sess.AccessToken, nil
+	// Result of Authorize is not used by gothic
+	return "", nil
 }

--- a/providers/direct/session.go
+++ b/providers/direct/session.go
@@ -1,0 +1,47 @@
+package direct
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/markbates/goth"
+)
+
+type DirectSession struct {
+	AuthURL     string
+	AccessToken string
+	Email       string
+}
+
+func (s *DirectSession) GetAuthURL() (string, error) {
+	return s.AuthURL, nil
+}
+
+func (s *DirectSession) Marshal() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func (s *DirectSession) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+	email := params.Get("email")
+	password := params.Get("password")
+
+	directProvider, ok := provider.(*DirectProvider)
+	if !ok {
+		return "", errors.New("invalid provider type")
+	}
+
+	session, err := directProvider.IssueSession(email, password)
+	if err != nil {
+		return "", err
+	}
+
+	sess, ok := session.(*DirectSession)
+	if !ok {
+		return "", errors.New("invalid session type")
+	}
+
+	s.AccessToken = sess.AccessToken
+	s.Email = sess.Email
+	return sess.AccessToken, nil
+}

--- a/providers/direct/session.go
+++ b/providers/direct/session.go
@@ -7,26 +7,26 @@ import (
 	"github.com/markbates/goth"
 )
 
-type DirectSession struct {
+type Session struct {
 	AuthURL     string
 	AccessToken string
 	Email       string
 }
 
-func (s *DirectSession) GetAuthURL() (string, error) {
+func (s *Session) GetAuthURL() (string, error) {
 	return s.AuthURL, nil
 }
 
-func (s *DirectSession) Marshal() string {
+func (s *Session) Marshal() string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
 
-func (s *DirectSession) Authorize(provider goth.Provider, params goth.Params) (string, error) {
+func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string, error) {
 	email := params.Get("email")
 	password := params.Get("password")
 
-	directProvider, ok := provider.(*DirectProvider)
+	directProvider, ok := provider.(*Provider)
 	if !ok {
 		return "", errors.New("invalid provider type")
 	}
@@ -36,7 +36,7 @@ func (s *DirectSession) Authorize(provider goth.Provider, params goth.Params) (s
 		return "", err
 	}
 
-	sess, ok := session.(*DirectSession)
+	sess, ok := session.(*Session)
 	if !ok {
 		return "", errors.New("invalid session type")
 	}

--- a/providers/direct/session_test.go
+++ b/providers/direct/session_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestDirectSession(t *testing.T) {
 	t.Run("Marshal", func(t *testing.T) {
-		session := &direct.DirectSession{
+		session := &direct.Session{
 			AccessToken: "1234567890",
 			Email:       "test@mail.com",
 			AuthURL:     "/login",
 		}
 		marshaled := session.Marshal()
 
-		var unmarshaled direct.DirectSession
+		var unmarshaled direct.Session
 		err := json.Unmarshal([]byte(marshaled), &unmarshaled)
 
 		if err != nil {
@@ -37,7 +37,7 @@ func TestDirectSession(t *testing.T) {
 	})
 
 	t.Run("GetAuthURL", func(t *testing.T) {
-		session := &direct.DirectSession{
+		session := &direct.Session{
 			AuthURL: "/",
 		}
 

--- a/providers/direct/session_test.go
+++ b/providers/direct/session_test.go
@@ -10,9 +10,8 @@ import (
 func TestDirectSession(t *testing.T) {
 	t.Run("Marshal", func(t *testing.T) {
 		session := &direct.Session{
-			AccessToken: "1234567890",
-			Email:       "test@mail.com",
-			AuthURL:     "/login",
+			Email:   "test@mail.com",
+			AuthURL: "/login",
 		}
 		marshaled := session.Marshal()
 
@@ -21,10 +20,6 @@ func TestDirectSession(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("unexpected error when unmarshaling session data: %v", err)
-		}
-
-		if unmarshaled.AccessToken != session.AccessToken {
-			t.Errorf("expected access token to be '%s', got '%s'", session.AccessToken, unmarshaled.AccessToken)
 		}
 
 		if unmarshaled.Email != session.Email {

--- a/providers/direct/session_test.go
+++ b/providers/direct/session_test.go
@@ -1,0 +1,53 @@
+package direct_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/markbates/goth/providers/direct"
+)
+
+func TestDirectSession(t *testing.T) {
+	t.Run("Marshal", func(t *testing.T) {
+		session := &direct.DirectSession{
+			AccessToken: "1234567890",
+			Email:       "test@mail.com",
+			AuthURL:     "/login",
+		}
+		marshaled := session.Marshal()
+
+		var unmarshaled direct.DirectSession
+		err := json.Unmarshal([]byte(marshaled), &unmarshaled)
+
+		if err != nil {
+			t.Errorf("unexpected error when unmarshaling session data: %v", err)
+		}
+
+		if unmarshaled.AccessToken != session.AccessToken {
+			t.Errorf("expected access token to be '%s', got '%s'", session.AccessToken, unmarshaled.AccessToken)
+		}
+
+		if unmarshaled.Email != session.Email {
+			t.Errorf("expected email to be '%s', got '%s'", session.Email, unmarshaled.Email)
+		}
+
+		if unmarshaled.AuthURL != session.AuthURL {
+			t.Errorf("expected auth url to be '%s', got '%s'", session.AuthURL, unmarshaled.AuthURL)
+		}
+	})
+
+	t.Run("GetAuthURL", func(t *testing.T) {
+		session := &direct.DirectSession{
+			AuthURL: "/",
+		}
+
+		url, err := session.GetAuthURL()
+		if err != nil {
+			t.Error("unexpected error when calling GetAuthURL")
+		}
+
+		if url != "/" {
+			t.Errorf("expected auth url to be '/', got '%s'", url)
+		}
+	})
+}


### PR DESCRIPTION
## Why
Goth is probably the current best authentication library in the Go ecosystem but it is lacking direct username/password flow. Adding Password Grant flow is likely to increase adoption.

## How
This PR adds a `direct` provider implementing the Password Grant flow as a Goth provider.
Implementation works as follows:

```mermaid
sequenceDiagram
    participant Client as Client
    participant Server as Server
    participant DirectProvider as DirectProvider
    Client->>Server: GET /auth/direct
    Server->>Server: Creates empty session and redirect to AuthURL ui
    Server-->>Client: 
    Client->>Server: POST /auth/direct with email & password
    Server->>DirectProvider: IssueSession(email, password)
    DirectProvider->>Server: Return Session with AccessToken
    Server->>DirectProvider: FetchUser(email)
    DirectProvider->>Server: Return User data
    Server->>Client: Return authenticated user data or error
```

This implementation aims to be as consistent as possible with the existing patterns in the codebase, meaning that it is designed to work seamlessly with the existing utilities (like `CompleteUserAuth`). As such, this feature appears as the addition of an additional provider.

**Note:** Not coupling the password grant to the `CompleteUserAuth` function has a small disadvantage. It is not possible to perform a request directly by providing a form, as an empty session is still not created but needed to progress through the `CompleteUserAuth` function. As a result, an intermediate redirect occurs, creating the required session for login. This is not ideal, as a "standard" user login page typically displays the login form right away. Please let me know if anyone has better ideas on how to handle this.