### PR TITLE
twitch: Sync scopes with the latest API specs

### DIFF
--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -22,64 +22,95 @@ const (
 const (
 	// ScopeAnalyticsReadExtensions provides access to view analytics data for
 	// the Twitch Extensions owned by the authenticated account.
-	ScopeAnalyticsReadExtensions string = "analytics:read:extensions"
+	ScopeAnalyticsReadExtensions = "analytics:read:extensions"
 	// ScopeAnalyticsReadGames provides accesss to view analytics data for the
 	// games owned by the authenticated account.
 	ScopeAnalyticsReadGames = "analytics:read:games"
 	// ScopeBitsRead provides access to view Bits information for a channel.
 	ScopeBitsRead = "bits:read"
-	// ScopeChannelEditCommercial provides access to run commercials on a
-	// channel.
-	ScopeChannelEditCommercial = "channel:edit:commercial"
 	// ScopeChannelManageBroadcast provides access to manage a channel’s
 	// broadcast configuration, including updating channel configuration and
 	// managing stream markers and stream tags.
 	ScopeChannelManageBroadcast = "channel:manage:broadcast"
+	// ScopeChannelReadCharity provides access to read charity campaign details
+	// and user donations on your channel.
+	ScopeChannelReadCharity = "channel:read:charity"
+	// ScopeChannelEditCommercial provides access to run commercials on a
+	// channel.
+	ScopeChannelEditCommercial = "channel:edit:commercial"
+	// ScopeChannelReadEditors provides access to view a list of users with the
+	// editor role for a channel.
+	ScopeChannelReadEditors = "channel:read:editors"
 	// ScopeChannelManageExtensions provides access to manage a channel’s
 	// Extension configuration, including activating Extensions.
 	ScopeChannelManageExtensions = "channel:manage:extensions"
+	// ScopeChannelReadGoals provides access to view Creator Goals for a
+	// channel.
+	ScopeChannelReadGoals = "channel:read:goals"
+	// ScopeChannelReadGuestStar provides access to read Guest Star details
+	// for your channel.
+	ScopeChannelReadGuestStar = "channel:read:guest_star"
+	// ScopeChannelManageGuestStar provides access to manage Guest Star
+	// for your channel.
+	ScopeChannelManageGuestStar = "channel:manage:guest_star"
+	// ScopeChannelReadHypeTrain provides access to view Hype Train information
+	// for a channel.
+	ScopeChannelReadHypeTrain = "channel:read:hype_train"
+	// ScopeChannelManageModerators provides access to add or remove the
+	// moderator role from users in your channel.
+	ScopeChannelManageModerators = "channel:manage:moderators"
+	// ScopeChannelReadPolls provides access to view a channel’s polls.
+	ScopeChannelReadPolls = "channel:read:polls"
 	// ScopeChannelManagePolls provides access to manage a channel’s polls.
 	ScopeChannelManagePolls = "channel:manage:polls"
+	// ScopeChannelReadPredictions provides access to view a channel’s Channel
+	// Points Predictions.
+	ScopeChannelReadPredictions = "channel:read:predictions"
 	// ScopeChannelManagePredictions provides access to manage a channel’s
 	// Channel Points Predictions.
 	ScopeChannelManagePredictions = "channel:manage:predictions"
+	// ScopeChannelManageRaids provides access to manage a channel raiding another channel.
+	ScopeChannelManageRaids = "channel:manage:raids"
+	// ScopeChannelReadRedemptions provides access to view Channel Points custom
+	// rewards and their redemptions on a channel.
+	ScopeChannelReadRedemptions = "channel:read:redemptions"
 	// ScopeChannelManageRedemptions provides access to manage Channel Points
 	// custom rewards and their redemptions on a channel.
 	ScopeChannelManageRedemptions = "channel:manage:redemptions"
 	// ScopeChannelManageSchedule provides access to manage a channel’s stream
 	// schedule.
 	ScopeChannelManageSchedule = "channel:manage:schedule"
-	// ScopeChannelManageVideos provides access to manage a channel’s videos,
-	// including deleting videos.
-	ScopeChannelManageVideos = "channel:manage:videos"
-	// ScopeChannelReadEditors provides access to view a list of users with the
-	// editor role for a channel.
-	ScopeChannelReadEditors = "channel:read:editors"
-	// ScopeChannelReadGoals provides access to view Creator Goals for a
-	// channel.
-	ScopeChannelReadGoals = "channel:read:goals"
-	// ScopeChannelReadHypeTrain provides access to view Hype Train information
-	// for a channel.
-	ScopeChannelReadHypeTrain = "channel:read:hype_train"
-	// ScopeChannelReadPolls provides access to view a channel’s polls.
-	ScopeChannelReadPolls = "channel:read:polls"
-	// ScopeChannelReadPredictions provides access to view a channel’s Channel
-	// Points Predictions.
-	ScopeChannelReadPredictions = "channel:read:predictions"
-	// ScopeChannelReadRedemptions provides access to view Channel Points custom
-	// rewards and their redemptions on a channel.
-	ScopeChannelReadRedemptions = "channel:read:redemptions"
 	// ScopeChannelReadStreamKey provides access to view an authorized user’s
 	// stream key.
 	ScopeChannelReadStreamKey = "channel:read:stream_key"
 	// ScopeChannelReadSubscriptions provides access to view a list of all
 	// subscribers to a channel and check if a user is subscribed to a channel.
 	ScopeChannelReadSubscriptions = "channel:read:subscriptions"
+	// ScopeChannelManageVideos provides access to manage a channel’s videos,
+	// including deleting videos.
+	ScopeChannelManageVideos = "channel:manage:videos"
+	// ScopeChannelReadVips provides access to read the list of VIPs in your channel.
+	ScopeChannelReadVips = "channel:read:vips"
+	// ScopeChannelManageVips provide access to add or remove the VIP role from
+	// users in your channel.
+	ScopeChannelManageVips = "channel:manage:vips"
 	// ScopeClipsEdit provides access to manage Clips for a channel.
 	ScopeClipsEdit = "clips:edit"
 	// ScopeModerationRead provides access to view a channel’s moderation data
 	// including Moderators, Bans, Timeouts, and AutoMod settings.
 	ScopeModerationRead = "moderation:read"
+	// ScopeModeratorManageAnnouncements provides access to send announcements
+	// in channels where you have the moderator role.
+	ScopeModeratorManageAnnouncements = "moderator:manage:announcements"
+	// ScopeModeratorManageAutomod provides access to manage messages held for
+	// review by AutoMod in channels where you are a moderator.
+	ScopeModeratorManageAutomod = "moderator:manage:automod"
+	// ScopeModeratorReadAutomodSettings provides access to view a broadcaster’s
+	// AutoMod settings.
+	ScopeModeratorReadAutomodSettings = "moderator:read:automod_settings"
+	// ScopeModeratorManageAutomodSettings provides access to manage a broadcaster’s
+	// AutoMod settings.
+	ScopeModeratorManageAutomodSettings = "moderator:manage:automod_settings"
 	// ScopeModeratorManageBannedUsers provides access to ban and unban users.
 	ScopeModeratorManageBannedUsers = "moderator:manage:banned_users"
 	// ScopeModeratorReadBlockedTerms provides access to view a broadcaster’s
@@ -88,35 +119,53 @@ const (
 	// ScopeModeratorManageBlockedTerms provides access to manage a
 	// broadcaster’s list of blocked terms.
 	ScopeModeratorManageBlockedTerms = "moderator:manage:blocked_terms"
-	// ScopeModeratorManageAutoMod provides access to manage messages held for
-	// review by AutoMod in channels where you are a moderator.
-	ScopeModeratorManageAutoMod = "moderator:manage:automod"
-	// ScopeModeratorReadAutoModSettings provides access to view a broadcaster’s
-	// AutoMod settings.
-	ScopeModeratorReadAutoModSettings = "moderator:read:automod_settings"
-	// ScopeModeratorManageAutoModSettings provides access to manage a
-	// broadcaster’s AutoMod settings.
-	ScopeModeratorManageAutoModSettings = "moderator:manage:automod_settings"
+	// ScopeModeratorManageChatMessages provides access to delete chat messages
+	// in channels where you have the moderator role
+	ScopeModeratorManageChatMessages = "moderator:manage:chat_messages"
 	// ScopeModeratorReadChatSettings provides access to view a broadcaster’s
 	// chat room settings.
 	ScopeModeratorReadChatSettings = "moderator:read:chat_settings"
 	// ScopeModeratorManageChatSettings provides access to manage a
 	// broadcaster’s chat room settings.
 	ScopeModeratorManageChatSettings = "moderator:manage:chat_settings"
+	// ScopeModeratorReadChatters provides access to view the chatters
+	// in a broadcaster’s chat room.
+	ScopeModeratorReadChatters = "moderator:read:chatters"
+	// ScopeModeratorReadFollowers provides access to read the followers of a broadcaster.
+	ScopeModeratorReadFollowers = "moderator:read:followers"
+	// ScopeModeratorReadGuestStar provides access to read Guest Star details
+	// for channels where you are a Guest Star moderator.
+	ScopeModeratorReadGuestStar = "moderator:read:guest_star"
+	// ScopeModeratorManageGuestStar provides access to Manage Guest Star for
+	// channels where you are a Guest Star moderator.
+	ScopeModeratorManageGuestStar = "moderator:manage:guest_star"
+	// ScopeModeratorReadShieldMode provides access to view a broadcaster’s
+	// Shield Mode status.
+	ScopeModeratorReadShieldMode = "moderator:read:shield_mode"
+	// ScopeModeratorManageShieldMode provides access to manage a broadcaster’s
+	// Shield Mode status.
+	ScopeModeratorManageShieldMode = "moderator:manage:shield_mode"
+	// ScopeModeratorReadShoutouts provides access to view a broadcaster’s shoutouts.
+	ScopeModeratorReadShoutouts = "moderator:read:shoutouts"
+	// ScopeModeratorManageShoutouts provides access to manage a broadcaster’s shoutouts.
+	ScopeModeratorManageShoutouts = "moderator:manage:shoutouts"
 	// ScopeUserEdit provides access to manage a user object.
 	ScopeUserEdit = "user:edit"
 	// ScopeUserEditFollows is deprecated. Was previously used for
 	// “Create User Follows” and “Delete User Follows.”
 	ScopeUserEditFollows = "user:edit:follows"
-	// ScopeUserManageBlockedUsers provides access to manage the block list of a
-	// user.
-	ScopeUserManageBlockedUsers = "user:manage:blocked_users"
 	// ScopeUserReadBlockedUsers provides access to view the block list of a
 	// user.
 	ScopeUserReadBlockedUsers = "user:read:blocked_users"
+	// ScopeUserManageBlockedUsers provides access to manage the block list of a
+	// user.
+	ScopeUserManageBlockedUsers = "user:manage:blocked_users"
 	// ScopeUserReadBroadcast provides access to view a user’s broadcasting
 	// configuration, including Extension configurations.
 	ScopeUserReadBroadcast = "user:read:broadcast"
+	// ScopeUserManageChatColor provides access to update the color use
+	// for the user’s name in chat.
+	ScopeUserManageChatColor = "user:manage:chat_color"
 	// ScopeUserReadEmail provides access to view a user’s email address.
 	ScopeUserReadEmail = "user:read:email"
 	// ScopeUserReadFollows provides access to view the list of channels a user
@@ -125,6 +174,20 @@ const (
 	// ScopeUserReadSubscriptions provides access to view if an authorized user
 	// is subscribed to specific channels.
 	ScopeUserReadSubscriptions = "user:read:subscriptions"
+	// ScopeUserManageWhispers provides access to read whispers that you send and receive,
+	// and send whispers on your behalf.
+	ScopeUserManageWhispers = "user:manage:whispers"
+	// ScopeChannelModerate provides access to perform moderation actions in a channel.
+	// The user requesting the scope must be a moderator in the channel.
+	ScopeChannelModerate = "channel:moderate"
+	// ScopeChatEdit provides access to send live stream chat messages.
+	ScopeChatEdit = "chat:edit"
+	// ScopeChatRead provides access to view live stream chat messages.
+	ScopeChatRead = "chat:read"
+	// ScopeWhispersRead provides access to view your whisper messages.
+	ScopeWhispersRead = "whispers:read"
+	// ScopeWhispersEdit provides access to send whisper messages.
+	ScopeWhispersEdit = "whispers:edit"
 
 	// ScopeChannelSubscriptions is a v5 scope.
 	ScopeChannelSubscriptions = ScopeChannelReadSubscriptions


### PR DESCRIPTION
Sync Twitch API scopes according to the latest specification available [here](https://dev.twitch.tv/docs/authentication/scopes/).

I used the following code to generate variable-scope code. It may be helpful for further syncs. :sweat_smile: 

```javascript
let scopeNames = Array.from(document.getElementsByClassName(
    'highlighter-rouge')).filter(element => element.innerText
    .match(/^[a-z:]+$/));

for (let i of scopeNames) {
    let elementText = i.innerText;
    let capitalizedScopeName =
        `Scope${elementText.split(/[:_]/).map((element) => element.charAt(0).toUpperCase() + element.slice(1)).join('')}`;
    console.log(`${capitalizedScopeName} = "${elementText}"`);
}
```