### PR TITLE
make providers map safe for concurrency

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"golang.org/x/oauth2"
 )
@@ -23,15 +24,21 @@ type Provider interface {
 
 const NoAuthUrlErrorMessage = "an AuthURL has not been set"
 
-// Providers is list of known/available providers.
+// Providers is the list of known/available providers.
 type Providers map[string]Provider
 
-var providers = Providers{}
+var (
+	providersHat sync.RWMutex
+	providers    = Providers{}
+)
 
 // UseProviders adds a list of available providers for use with Goth.
 // Can be called multiple times. If you pass the same provider more
 // than once, the last will be used.
 func UseProviders(viders ...Provider) {
+	providersHat.Lock()
+	defer providersHat.Unlock()
+
 	for _, provider := range viders {
 		providers[provider.Name()] = provider
 	}
@@ -45,7 +52,9 @@ func GetProviders() Providers {
 // GetProvider returns a previously created provider. If Goth has not
 // been told to use the named provider it will return an error.
 func GetProvider(name string) (Provider, error) {
+	providersHat.RLock()
 	provider := providers[name]
+	providersHat.RUnlock()
 	if provider == nil {
 		return nil, fmt.Errorf("no provider for %s exists", name)
 	}
@@ -55,6 +64,9 @@ func GetProvider(name string) (Provider, error) {
 // ClearProviders will remove all providers currently in use.
 // This is useful, mostly, for testing purposes.
 func ClearProviders() {
+	providersHat.Lock()
+	defer providersHat.Unlock()
+
 	providers = Providers{}
 }
 


### PR DESCRIPTION
I have a `goth.UseProviders` that is tested in a bunch of tests, and I get data race warnings because the providers map is unprotected. I've added a [mutex hat](https://dmitri.shuralyov.com/idiomatic-go/entries/2) to guard it. :) 