### PR TITLE
add providers resolver

### DIFF
--- a/provider_test.go
+++ b/provider_test.go
@@ -33,3 +33,36 @@ func Test_GetProvider(t *testing.T) {
 	a.Equal(err.Error(), "no provider for unknown exists")
 	goth.ClearProviders()
 }
+
+func Test_CustomResolver(t *testing.T) {
+	a := assert.New(t)
+	resolver := &CustomResolver{}
+	goth.SetProviderResolver(resolver)
+	p, err := goth.GetProvider("faux")
+	a.NoError(err)
+	a.Equal(len(goth.GetProviders()), 1)
+	a.NotNil(p)
+
+	p, err = goth.GetProvider("unknown")
+	a.NoError(err)
+	a.Nil(p)
+
+	goth.ClearProviders()
+}
+
+type CustomResolver struct{}
+
+func (r CustomResolver) Get(name string) (goth.Provider, error) {
+	// you can load this from a database or something
+	if name != "faux" {
+		return nil, nil
+	}
+	return &faux.Provider{}, nil
+}
+
+func (r CustomResolver) GetAll() goth.Providers {
+	// you can load this from a database or something
+	return goth.Providers{
+		"faux": &faux.Provider{},
+	}
+}


### PR DESCRIPTION

Providers config (`client_id`, `client_secret`, etc) can be stored in a database and change while the application is running.
The current syntax does not allow to handle this usecase.

```go
goth.UseProviders(providers) // static data
```

This PR introduces a new interface:

```go
type ProviderResolver interface {
  Get(name string) (Provider, error)
  GetAll() Providers
}
```

```go
// For backward compatibility, goth.UseProviders(providers) now becomes :

func UseProviders(viders ...Provider) {
	providers := Providers{}
	for _, p := range viders {
		providers[p.Name()] = p
	}
	resolver = DefaultProviderResolver{providers: providers}
}
```

Now it becomes possible to do something like:

```go

type MyCustomResolver struct{
  db *gorm.DB
}

func (r MyCustomResolver) Get(name string) (goth.Provider, error) {
   // do your magic
}

func (r MyCustomResolver) GetAll() goth.Providers {
  // do your magic
}

goth.SetProviderResolver(&MyCustomResolver{db: db})
```
