### PR TITLE
Fix deezer authentication

### DIFF
--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	authURL         string = "https://connect.deezer.com/oauth/auth.php"
-	tokenURL        string = "https://connect.deezer.com/oauth/access_token.php"
+	tokenURL        string = "https://connect.deezer.com/oauth/access_token.php?output=json"
 	endpointProfile string = "https://api.deezer.com/user/me"
 )
 


### PR DESCRIPTION
Deezer authorize was not working since it returns plain text by default. See : [https://developers.deezer.com/api/oauth](https://developers.deezer.com/api/oauth)
It is now fully working.