### PR TITLE
Since go 1.22 path variables are supported

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -287,6 +287,12 @@ func getProviderName(req *http.Request) (string, error) {
 		return p, nil
 	}
 
+	// since go-1.22 this is also supported
+	// see: https://go.dev/blog/routing-enhancements
+	if p := req.PathValue("provider"); p != "" {
+		return p, nil
+	}
+
 	// As a fallback, loop over the used providers, if we already have a valid session for any provider (ie. user has already begun authentication with a provider), then return that provider name
 	providers := goth.GetProviders()
 	session, _ := Store.Get(req, SessionName)


### PR DESCRIPTION
Since go-1.22 the http handler supports path variables in the same way gorilla/mux does. Support this.