### PR TITLE
Pickup provider name from go 1.22 mux

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -262,6 +262,10 @@ var GetProviderName = getProviderName
 
 func getProviderName(req *http.Request) (string, error) {
 
+	if p:= req.PathValue("provider"); p != "" {
+		return p, nil
+	}
+
 	// try to get it from the url param "provider"
 	if p := req.URL.Query().Get("provider"); p != "" {
 		return p, nil


### PR DESCRIPTION
Using the new mux addet to go 1.22 natively, the provider name is not picked up. It mostly replaces `gorilla/pat` in many places, e.g. path parameters.   

There is the alternative of working around this like this:
```go
	mux.HandleFunc("GET /auth/{provider}", func(res http.ResponseWriter, req *http.Request) {
		// try to get the user without re-authenticating

		// goth doesn't pick up the provider using the go 1.22 new routers, so
		// we work around by setting it in the context.
		req = req.WithContext(context.WithValue(req.Context(), "provider", req.PathValue("provider")))

		if gothUser, err := gothic.CompleteUserAuth(res, req); err == nil {
			err = templates.ExecuteTemplate(res, "user.html", gothUser)
			if err != nil {
				panic(err)
			}
		} else {

			gothic.BeginAuthHandler(res, req)
		}
	})
```  

By merging this PR it would no longer be necessary to set the provider explicitely in the context of the request.