### PR TITLE
Adding get provider name support for chi router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/markbates/goth
 go 1.18
 
 require (
+	github.com/go-chi/chi/v5 v5.1.0
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/mux v1.6.2
 	github.com/gorilla/pat v0.0.0-20180118222023-199c85a7f6d1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
@@ -279,6 +280,11 @@ func getProviderName(req *http.Request) (string, error) {
 
 	//  try to get it from the go-context's value of "provider" key
 	if p, ok := req.Context().Value("provider").(string); ok {
+		return p, nil
+	}
+
+	// try to get it from the url param "provider", when req is routed through 'chi'
+	if p := chi.URLParam(req, "provider"); p != "" {
 		return p, nil
 	}
 


### PR DESCRIPTION
[Chi](https://github.com/go-chi/chi), one of the fastest and most lightweight routers for Go. When it is used for routing requests to a Gothic handler like below, Gothic fails to get the value of the 'provider' parameter.
```go
func signUpRouter() *chi.Mux {
	r := chi.NewRouter()
	r.Get("/{provider}", gothic.BeginAuthHandler)
	return r
}
```
The way to get the parameter value from a Chi request is `chi.URLParam(r, paramName)`. However, inside the `getProviderName` function of Gothic, there is no support for this extraction method.

By merging this PR, it will no longer be necessary to set the provider explicitly in the context of the request to get Gothic working with the Chi router.