### PR TITLE
Add 1.22 mux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.22.x ]
+        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x ]
+        go-version: [ 1.22.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ node_modules/
 dist/
 generated/
 .vendor/
+vendor
 *.swp
 .vscode/launch.json
 .vscode/settings.json

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/markbates/goth
 
-go 1.22
+go 1.18
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/markbates/goth
 
-go 1.18
+go 1.22
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
 )
@@ -251,64 +249,6 @@ func Logout(res http.ResponseWriter, req *http.Request) error {
 		return errors.New("Could not delete user session ")
 	}
 	return nil
-}
-
-// GetProviderName is a function used to get the name of a provider
-// for a given request. By default, this provider is fetched from
-// the URL query string. If you provide it in a different way,
-// assign your own function to this variable that returns the provider
-// name for your request.
-var GetProviderName = getProviderName
-
-func getProviderName(req *http.Request) (string, error) {
-	// try to get it from the url param "provider"
-	if p := req.URL.Query().Get("provider"); p != "" {
-		return p, nil
-	}
-
-	// try to get it from the url param ":provider"
-	if p := req.URL.Query().Get(":provider"); p != "" {
-		return p, nil
-	}
-
-	// try to get it from the context's value of "provider" key
-	if p, ok := mux.Vars(req)["provider"]; ok {
-		return p, nil
-	}
-
-	//  try to get it from the go-context's value of "provider" key
-	if p, ok := req.Context().Value("provider").(string); ok {
-		return p, nil
-	}
-
-	// try to get it from the url param "provider", when req is routed through 'chi'
-	if p := chi.URLParam(req, "provider"); p != "" {
-		return p, nil
-	}
-
-	// try to get it from the route param for go >= 1.22
-	if p := req.PathValue("provider"); p != "" {
-		return p, nil
-	}
-
-	// try to get it from the go-context's value of providerContextKey key
-	if p, ok := req.Context().Value(ProviderParamKey).(string); ok {
-		return p, nil
-	}
-
-	// As a fallback, loop over the used providers, if we already have a valid session for any provider (ie. user has already begun authentication with a provider), then return that provider name
-	providers := goth.GetProviders()
-	session, _ := Store.Get(req, SessionName)
-	for _, provider := range providers {
-		p := provider.Name()
-		value := session.Values[p]
-		if _, ok := value.(string); ok {
-			return p, nil
-		}
-	}
-
-	// if not found then return an empty string with the corresponding error
-	return "", errors.New("you must select a provider")
 }
 
 // GetContextWithProvider returns a new request context containing the provider

--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -262,7 +261,6 @@ func Logout(res http.ResponseWriter, req *http.Request) error {
 var GetProviderName = getProviderName
 
 func getProviderName(req *http.Request) (string, error) {
-
 	// try to get it from the url param "provider"
 	if p := req.URL.Query().Get("provider"); p != "" {
 		return p, nil
@@ -285,6 +283,11 @@ func getProviderName(req *http.Request) (string, error) {
 
 	// try to get it from the url param "provider", when req is routed through 'chi'
 	if p := chi.URLParam(req, "provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the route param for go >= 1.22
+	if p := req.PathValue("provider"); p != "" {
 		return p, nil
 	}
 
@@ -347,7 +350,7 @@ func getSessionValue(session *sessions.Session, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	s, err := ioutil.ReadAll(r)
+	s, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
 	}

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -98,9 +98,8 @@ func Test_GetAuthURL(t *testing.T) {
 	a := assert.New(t)
 
 	res := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/auth", nil)
+	req, err := http.NewRequest("GET", "/auth?provider=faux", nil)
 	a.NoError(err)
-	req.SetPathValue("provider", "faux")
 
 	u, err := GetAuthURL(res, req)
 	a.NoError(err)
@@ -119,7 +118,6 @@ func Test_GetAuthURL(t *testing.T) {
 	// auth URL has a different state from the previous one.
 	req2, err := http.NewRequest("GET", "/auth?provider=faux", nil)
 	a.NoError(err)
-	req2.SetPathValue("provider", "faux")
 	url2, err := GetAuthURL(httptest.NewRecorder(), req2)
 	a.NoError(err)
 	parsed2, err := url.Parse(url2)

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -98,8 +98,9 @@ func Test_GetAuthURL(t *testing.T) {
 	a := assert.New(t)
 
 	res := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/auth?provider=faux", nil)
+	req, err := http.NewRequest("GET", "/auth", nil)
 	a.NoError(err)
+	req.SetPathValue("provider", "faux")
 
 	u, err := GetAuthURL(res, req)
 	a.NoError(err)
@@ -118,6 +119,7 @@ func Test_GetAuthURL(t *testing.T) {
 	// auth URL has a different state from the previous one.
 	req2, err := http.NewRequest("GET", "/auth?provider=faux", nil)
 	a.NoError(err)
+	req2.SetPathValue("provider", "faux")
 	url2, err := GetAuthURL(httptest.NewRecorder(), req2)
 	a.NoError(err)
 	parsed2, err := url.Parse(url2)
@@ -283,7 +285,7 @@ func ungzipString(value string) string {
 	if err != nil {
 		return "err"
 	}
-	s, err := ioutil.ReadAll(r)
+	s, err := io.ReadAll(r)
 	if err != nil {
 		return "err"
 	}

--- a/gothic/provider.go
+++ b/gothic/provider.go
@@ -1,0 +1,71 @@
+//go:build go1.22
+// +build go1.22
+
+package gothic
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/mux"
+	"github.com/markbates/goth"
+)
+
+// GetProviderName is a function used to get the name of a provider
+// for a given request. By default, this provider is fetched from
+// the URL query string. If you provide it in a different way,
+// assign your own function to this variable that returns the provider
+// name for your request.
+var GetProviderName = getProviderName
+
+func getProviderName(req *http.Request) (string, error) {
+	// try to get it from the url param "provider"
+	if p := req.URL.Query().Get("provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the url param ":provider"
+	if p := req.URL.Query().Get(":provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the context's value of "provider" key
+	if p, ok := mux.Vars(req)["provider"]; ok {
+		return p, nil
+	}
+
+	//  try to get it from the go-context's value of "provider" key
+	if p, ok := req.Context().Value("provider").(string); ok {
+		return p, nil
+	}
+
+	// try to get it from the url param "provider", when req is routed through 'chi'
+	if p := chi.URLParam(req, "provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the route param for go >= 1.22
+	if p := req.PathValue("provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the go-context's value of providerContextKey key
+	if p, ok := req.Context().Value(ProviderParamKey).(string); ok {
+		return p, nil
+	}
+
+	// As a fallback, loop over the used providers, if we already have a valid session for any provider (ie. user has already begun authentication with a provider), then return that provider name
+	providers := goth.GetProviders()
+	session, _ := Store.Get(req, SessionName)
+	for _, provider := range providers {
+		p := provider.Name()
+		value := session.Values[p]
+		if _, ok := value.(string); ok {
+			return p, nil
+		}
+	}
+
+	// if not found then return an empty string with the corresponding error
+	return "", errors.New("you must select a provider")
+}

--- a/gothic/provider_legacy.go
+++ b/gothic/provider_legacy.go
@@ -1,0 +1,66 @@
+//go:build !go1.22
+// +build !go1.22
+
+package gothic
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/mux"
+	"github.com/markbates/goth"
+)
+
+// GetProviderName is a function used to get the name of a provider
+// for a given request. By default, this provider is fetched from
+// the URL query string. If you provide it in a different way,
+// assign your own function to this variable that returns the provider
+// name for your request.
+var GetProviderName = getProviderName
+
+func getProviderName(req *http.Request) (string, error) {
+	// try to get it from the url param "provider"
+	if p := req.URL.Query().Get("provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the url param ":provider"
+	if p := req.URL.Query().Get(":provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the context's value of "provider" key
+	if p, ok := mux.Vars(req)["provider"]; ok {
+		return p, nil
+	}
+
+	//  try to get it from the go-context's value of "provider" key
+	if p, ok := req.Context().Value("provider").(string); ok {
+		return p, nil
+	}
+
+	// try to get it from the url param "provider", when req is routed through 'chi'
+	if p := chi.URLParam(req, "provider"); p != "" {
+		return p, nil
+	}
+
+	// try to get it from the go-context's value of providerContextKey key
+	if p, ok := req.Context().Value(ProviderParamKey).(string); ok {
+		return p, nil
+	}
+
+	// As a fallback, loop over the used providers, if we already have a valid session for any provider (ie. user has already begun authentication with a provider), then return that provider name
+	providers := goth.GetProviders()
+	session, _ := Store.Get(req, SessionName)
+	for _, provider := range providers {
+		p := provider.Name()
+		value := session.Values[p]
+		if _, ok := value.(string); ok {
+			return p, nil
+		}
+	}
+
+	// if not found then return an empty string with the corresponding error
+	return "", errors.New("you must select a provider")
+}

--- a/gothic/provider_test.go
+++ b/gothic/provider_test.go
@@ -1,0 +1,47 @@
+//go:build go1.22
+// +build go1.22
+
+package gothic_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/markbates/goth/gothic"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetAuthURL122(t *testing.T) {
+	a := assert.New(t)
+
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/auth", nil)
+	a.NoError(err)
+	req.SetPathValue("provider", "faux")
+
+	u, err := gothic.GetAuthURL(res, req)
+	a.NoError(err)
+
+	// Check that we get the correct auth URL with a state parameter
+	parsed, err := url.Parse(u)
+	a.NoError(err)
+	a.Equal("http", parsed.Scheme)
+	a.Equal("example.com", parsed.Host)
+	q := parsed.Query()
+	a.Contains(q, "client_id")
+	a.Equal("code", q.Get("response_type"))
+	a.NotZero(q, "state")
+
+	// Check that if we run GetAuthURL on another request, that request's
+	// auth URL has a different state from the previous one.
+	req2, err := http.NewRequest("GET", "/auth?provider=faux", nil)
+	a.NoError(err)
+	req2.SetPathValue("provider", "faux")
+	url2, err := gothic.GetAuthURL(httptest.NewRecorder(), req2)
+	a.NoError(err)
+	parsed2, err := url.Parse(url2)
+	a.NoError(err)
+	a.NotEqual(parsed.Query().Get("state"), parsed2.Query().Get("state"))
+}

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -95,7 +94,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/azureadv2/azureadv2.go
+++ b/providers/azureadv2/azureadv2.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -199,7 +198,7 @@ func userFromReader(r io.Reader, user *goth.User) error {
 		UserPrincipalName string   `json:"userPrincipalName"` // The user's principal name.
 	}{}
 
-	userBytes, err := ioutil.ReadAll(r)
+	userBytes, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/providers/battlenet/battlenet.go
+++ b/providers/battlenet/battlenet.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -103,7 +103,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -134,7 +134,7 @@ func (p *Provider) getUserInfo(user *goth.User, sess *Session) error {
 		return fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/providers/bitly/bitly.go
+++ b/providers/bitly/bitly.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -97,7 +96,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 	defer resp.Body.Close()
 
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return u, err
 	}

--- a/providers/classlink/provider.go
+++ b/providers/classlink/provider.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -102,7 +102,7 @@ func (p Provider) FetchUser(session goth.Session) (goth.User, error) {
 
 	defer resp.Body.Close()
 
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -104,7 +103,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(resp.Body)
+	bits, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/cognito/cognito.go
+++ b/providers/cognito/cognito.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -128,7 +127,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -97,7 +96,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -98,7 +97,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -105,7 +104,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(resp.Body)
+	bits, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -143,7 +142,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(resp.Body)
+	bits, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -105,7 +104,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(resp.Body)
+	bits, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/eveonline/eveonline.go
+++ b/providers/eveonline/eveonline.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -102,7 +102,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -127,7 +126,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/gitea/gitea.go
+++ b/providers/gitea/gitea.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -115,7 +114,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -126,7 +125,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("GitHub API responded with a %d trying to fetch user information", response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -116,7 +115,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -5,7 +5,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -110,7 +110,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	responseBytes, err := ioutil.ReadAll(response.Body)
+	responseBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/gplus/gplus.go
+++ b/providers/gplus/gplus.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -102,7 +101,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/hubspot/hubspot.go
+++ b/providers/hubspot/hubspot.go
@@ -3,13 +3,14 @@ package hubspot
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 // These vars define the Authentication and Token URLS for Hubspot.

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -129,7 +128,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -97,7 +96,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	authURL  = "https://app.intercom.iooauth"
-	tokenURL = "https://api.intercom.ioauth/eagle/token?client_secret=%s"
-	UserURL  = "https://api.intercom.iome"
+	authURL  = "https://app.intercom.io/oauth"
+	tokenURL = "https://api.intercom.io/auth/eagle/token?client_secret=%s"
+	UserURL  = "https://api.intercom.io/me"
 )
 
 // New creates the new Intercom provider

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -16,9 +15,9 @@ import (
 )
 
 var (
-	authURL  = "https://app.intercom.io/oauth"
-	tokenURL = "https://api.intercom.io/auth/eagle/token?client_secret=%s"
-	UserURL  = "https://api.intercom.io/me"
+	authURL  = "https://app.intercom.iooauth"
+	tokenURL = "https://api.intercom.ioauth/eagle/token?client_secret=%s"
+	UserURL  = "https://api.intercom.iome"
 )
 
 // New creates the new Intercom provider
@@ -105,7 +104,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/intercom/intercom_test.go
+++ b/providers/intercom/intercom_test.go
@@ -47,7 +47,7 @@ func Test_BeginAuth(t *testing.T) {
 	session, err := provider.BeginAuth("test_state")
 	s := session.(*intercom.Session)
 	a.NoError(err)
-	a.Contains(s.AuthURL, "https://app.intercom.io/oauth")
+	a.Contains(s.AuthURL, "https://app.intercom.iooauth")
 	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("INTERCOM_KEY")))
 	a.Contains(s.AuthURL, "state=test_state")
 }
@@ -58,10 +58,10 @@ func Test_SessionFromJSON(t *testing.T) {
 
 	provider := intercomProvider()
 
-	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.intercom.io/oauth","AccessToken":"1234567890"}`)
+	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.intercom.iooauth","AccessToken":"1234567890"}`)
 	a.NoError(err)
 	session := s.(*intercom.Session)
-	a.Equal(session.AuthURL, "https://app.intercom.io/oauth")
+	a.Equal(session.AuthURL, "https://app.intercom.iooauth")
 	a.Equal(session.AccessToken, "1234567890")
 }
 

--- a/providers/intercom/intercom_test.go
+++ b/providers/intercom/intercom_test.go
@@ -47,7 +47,7 @@ func Test_BeginAuth(t *testing.T) {
 	session, err := provider.BeginAuth("test_state")
 	s := session.(*intercom.Session)
 	a.NoError(err)
-	a.Contains(s.AuthURL, "https://app.intercom.iooauth")
+	a.Contains(s.AuthURL, "https://app.intercom.io/oauth")
 	a.Contains(s.AuthURL, fmt.Sprintf("client_id=%s", os.Getenv("INTERCOM_KEY")))
 	a.Contains(s.AuthURL, "state=test_state")
 }
@@ -58,10 +58,10 @@ func Test_SessionFromJSON(t *testing.T) {
 
 	provider := intercomProvider()
 
-	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.intercom.iooauth","AccessToken":"1234567890"}`)
+	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.intercom.io/oauth","AccessToken":"1234567890"}`)
 	a.NoError(err)
 	session := s.(*intercom.Session)
-	a.Equal(session.AuthURL, "https://app.intercom.iooauth")
+	a.Equal(session.AuthURL, "https://app.intercom.io/oauth")
 	a.Equal(session.AccessToken, "1234567890")
 }
 

--- a/providers/kakao/kakao.go
+++ b/providers/kakao/kakao.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -105,7 +105,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -8,7 +8,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -168,7 +168,7 @@ func (p *Provider) request(sign bool, params map[string]string, result interface
 		err = errors.New(fmt.Errorf("Request error(%v) %v", res.StatusCode, res.Status).Error())
 		return err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/providers/line/line.go
+++ b/providers/line/line.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -105,7 +105,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/mailru/mailru.go
+++ b/providers/mailru/mailru.go
@@ -5,7 +5,7 @@ package mailru
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -101,7 +101,7 @@ func (p *Provider) FetchUser(session goth.Session) (_ goth.User, err error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.name, res.StatusCode)
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/mastodon/mastodon.go
+++ b/providers/mastodon/mastodon.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -112,7 +111,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/meetup/meetup.go
+++ b/providers/meetup/meetup.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -104,7 +103,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/naver/naver.go
+++ b/providers/naver/naver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -72,7 +71,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/nextcloud/README.md
+++ b/providers/nextcloud/README.md
@@ -6,7 +6,7 @@ on your own private server.
 ## Setting up Nextcloud Test Environment
 
 To test, you only need a working Docker image of Nextcloud running on a public
-URL, e.g. through [traefik](https://traefik.io/)
+URL, e.g. through [traefik](https://traefik.io)
 
 ```docker-compose.yml
 version: '2'

--- a/providers/nextcloud/nextcloud.go
+++ b/providers/nextcloud/nextcloud.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -132,7 +131,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/okta/okta.go
+++ b/providers/okta/okta.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -109,7 +108,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -94,7 +93,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -288,7 +288,7 @@ func (p *Provider) RefreshTokenWithIDToken(refreshToken string) (*RefreshTokenRe
 		return nil, fmt.Errorf("Non-200 response from RefreshToken: %d, WWW-Authenticate=%s", resp.StatusCode, resp.Header.Get("WWW-Authenticate"))
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (p *Provider) fetchUserInfo(url, accessToken string) (map[string]interface{
 
 	// The UserInfo Claims MUST be returned as the members of a JSON object
 	// http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func getOpenIDConfig(p *Provider, openIDAutoDiscoveryURL string) (*OpenIDConfig,
 		return nil, fmt.Errorf("Non-success code for Discovery URL: %d", res.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/patreon/patreon.go
+++ b/providers/patreon/patreon.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -143,7 +142,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -126,7 +125,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/reddit/reddit.go
+++ b/providers/reddit/reddit.go
@@ -3,11 +3,12 @@ package reddit
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/markbates/goth"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/markbates/goth"
+	"golang.org/x/oauth2"
 )
 
 const (

--- a/providers/seatalk/seatalk.go
+++ b/providers/seatalk/seatalk.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -101,7 +101,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	responseBytes, err := ioutil.ReadAll(response.Body)
+	responseBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -104,7 +103,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}
@@ -130,7 +129,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 			return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 		}
 
-		bits, err = ioutil.ReadAll(response.Body)
+		bits, err = io.ReadAll(response.Body)
 		if err != nil {
 			return user, err
 		}

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -99,7 +98,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/steam/session.go
+++ b/providers/steam/session.go
@@ -4,7 +4,7 @@ package steam
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"regexp"
 	"strings"
@@ -56,7 +56,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", err
 	}
 	defer resp.Body.Close()
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/providers/strava/strava.go
+++ b/providers/strava/strava.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -101,7 +100,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/tiktok/session.go
+++ b/providers/tiktok/session.go
@@ -3,7 +3,7 @@ package tiktok
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -68,7 +68,7 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 	}{}
 
 	// Get the body bytes in case we have to parse an error response
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}

--- a/providers/tiktok/tiktok.go
+++ b/providers/tiktok/tiktok.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -143,7 +142,7 @@ func userFromReader(reader io.Reader, user *goth.User) error {
 		} `json:"data"`
 	}{}
 
-	bodyBytes, err := ioutil.ReadAll(reader)
+	bodyBytes, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}
@@ -207,7 +206,7 @@ func (p *Provider) RefreshToken(refreshToken string) (*oauth2.Token, error) {
 	}
 
 	// We get the body bytes in case we need to parse an error response
-	bodyBytes, err := ioutil.ReadAll(refreshResponse.Body)
+	bodyBytes, err := io.ReadAll(refreshResponse.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -118,7 +118,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -118,7 +118,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/typetalk/typetalk.go
+++ b/providers/typetalk/typetalk.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -103,7 +102,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user name", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}
@@ -133,7 +132,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch profile", p.providerName, response.StatusCode)
 	}
 
-	bits, err = ioutil.ReadAll(response.Body)
+	bits, err = io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/vk/vk.go
+++ b/providers/vk/vk.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -98,7 +97,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/xero/xero.go
+++ b/providers/xero/xero.go
@@ -7,7 +7,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -155,7 +155,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 	}
 
 	var apiResponse APIResponse
-	responseBytes, err := ioutil.ReadAll(response.Body)
+	responseBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, fmt.Errorf("Could not read response: %s", err.Error())
 	}
@@ -204,7 +204,7 @@ func newPublicConsumer(provider *Provider, authURL string) *oauth.Consumer {
 
 // newPartnerConsumer creates a consumer capable of communicating with a Partner application: https://developer.xero.com/documentation/auth-and-limits/partner-applications
 func newPrivateOrPartnerConsumer(provider *Provider, authURL string) *oauth.Consumer {
-	privateKeyFileContents, err := ioutil.ReadFile(privateKeyFilePath)
+	privateKeyFileContents, err := os.ReadFile(privateKeyFilePath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/providers/yammer/session.go
+++ b/providers/yammer/session.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -76,7 +75,7 @@ func retrieveAuthData(p *Provider, TokenURL string, v url.Values) (map[string]ma
 		return nil, err
 	}
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -99,7 +99,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, response.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(response.Body)
+	bits, err := io.ReadAll(response.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/yandex/yandex.go
+++ b/providers/yandex/yandex.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/markbates/goth"
@@ -103,7 +102,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s responded with a %d trying to fetch user information", p.providerName, resp.StatusCode)
 	}
 
-	bits, err := ioutil.ReadAll(resp.Body)
+	bits, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return user, err
 	}

--- a/providers/zoom/zoom_test.go
+++ b/providers/zoom/zoom_test.go
@@ -47,9 +47,9 @@ func Test_SessionFromJSON(t *testing.T) {
 
 	provider := zoomProvider()
 
-	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.zoom.io/oauth","AccessToken":"1234567890"}`)
+	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.zoom.iooauth","AccessToken":"1234567890"}`)
 	a.NoError(err)
 	session := s.(*zoom.Session)
-	a.Equal(session.AuthURL, "https://app.zoom.io/oauth")
+	a.Equal(session.AuthURL, "https://app.zoom.iooauth")
 	a.Equal(session.AccessToken, "1234567890")
 }

--- a/providers/zoom/zoom_test.go
+++ b/providers/zoom/zoom_test.go
@@ -47,9 +47,9 @@ func Test_SessionFromJSON(t *testing.T) {
 
 	provider := zoomProvider()
 
-	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.zoom.iooauth","AccessToken":"1234567890"}`)
+	s, err := provider.UnmarshalSession(`{"AuthURL":"https://app.zoom.io/oauth","AccessToken":"1234567890"}`)
 	a.NoError(err)
 	session := s.(*zoom.Session)
-	a.Equal(session.AuthURL, "https://app.zoom.iooauth")
+	a.Equal(session.AuthURL, "https://app.zoom.io/oauth")
 	a.Equal(session.AccessToken, "1234567890")
 }


### PR DESCRIPTION
This PR seems large; however, it fundamentally accomplishes 3 things.

1. Upgrade GO version to `1.22`
2. Add compatibility for the new 1.22 mux functionality to retrieve provider values
3. Removes all instances of `ioutil` with their non-deprecated `io` and `os` alternatives.

This this change and without any other modifications, this change breaks backward compatibility for GO <1.22. This can be fixed however by creating a new `gothic.go | gothic_test.go` with `//go:build go1.22` with these breaking changes. I am happy to make these compatibility changes but would love to get other's opinions first.