### PR TITLE
linkedin scopes updated to 'profile' and 'email' according to update …

### DIFF
--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -257,7 +257,7 @@ func newConfig(provider *Provider, scopes []string) *oauth2.Config {
 
 	if len(scopes) == 0 {
 		// add helper as new API requires the scope to be specified and these are the minimum to retrieve profile information and user's email address
-		scopes = append(scopes, "r_liteprofile", "r_emailaddress")
+		scopes = append(scopes, "profile", "email")
 	}
 
 	for _, scope := range scopes {


### PR DESCRIPTION
This pull request updates the LinkedIn OAuth scopes in the goth package to align with LinkedIn’s latest API requirements. LinkedIn has deprecated the previous scopes r_liteprofile and r_emailAddress and replaced them with profile and email. This change is essential to ensure that LinkedIn authentication continues to work as expected without encountering permission errors.

Changes Made:

Updated LinkedIn OAuth scopes in the relevant files from:

- r_liteprofile ➔ profile
- r_emailAddress ➔ email

Reason for Change: LinkedIn recently changed its API scope requirements, making r_liteprofile and r_emailAddress obsolete. Using the new scopes profile and email ensures compatibility with LinkedIn's API and allows applications to retrieve the necessary profile and email information without issues.