### PR TITLE
gothic: Add http PathValue() support to GetProviderName()

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -293,6 +293,11 @@ func getProviderName(req *http.Request) (string, error) {
 		return p, nil
 	}
 
+	// try to get it from the go v1.22+ path value
+	if p := req.PathValue("provider"); p != "" {
+		return p, nil
+	}
+
 	// As a fallback, loop over the used providers, if we already have a valid session for any provider (ie. user has already begun authentication with a provider), then return that provider name
 	providers := goth.GetProviders()
 	session, _ := Store.Get(req, SessionName)

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -188,6 +188,28 @@ func Test_CompleteUserAuthWithContextParamProvider(t *testing.T) {
 	a.Equal(user.Email, "homer@example.com")
 }
 
+func Test_CompleteUserAuthWithPathValueProvider(t *testing.T) {
+	a := assert.New(t)
+
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/auth/faux/callback", nil)
+	a.NoError(err)
+
+	req.SetPathValue("provider", "faux")
+
+	sess := faux.Session{Name: "Homer Simpson", Email: "homer@example.com"}
+	session, _ := Store.Get(req, SessionName)
+	session.Values["faux"] = gzipString(sess.Marshal())
+	err = session.Save(req, res)
+	a.NoError(err)
+
+	user, err := CompleteUserAuth(res, req)
+	a.NoError(err)
+
+	a.Equal(user.Name, "Homer Simpson")
+	a.Equal(user.Email, "homer@example.com")
+}
+
 func Test_Logout(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
Go [v1.22](https://tip.golang.org/doc/go1.22#enhanced_routing_patterns) added [ServeMux pattern](https://pkg.go.dev/net/http#hdr-Patterns-ServeMux) support, retrieved with [PathValue()](https://pkg.go.dev/net/http#Request.PathValue).