### PR TITLE
fix: base64 encode gzipped data

### DIFF
--- a/gothic/gothic.go
+++ b/gothic/gothic.go
@@ -330,7 +330,7 @@ func GetFromSession(key string, req *http.Request) (string, error) {
 	session, _ := Store.Get(req, SessionName)
 	value, err := getSessionValue(session, key)
 	if err != nil {
-		return "", errors.New("could not find a matching session for this request")
+		return "", err
 	}
 
 	return value, nil
@@ -343,7 +343,8 @@ func getSessionValue(session *sessions.Session, key string) (string, error) {
 	}
 
 	rdata := strings.NewReader(value.(string))
-	r, err := gzip.NewReader(rdata)
+	b64Reader := base64.NewDecoder(base64.StdEncoding, rdata)
+	r, err := gzip.NewReader(b64Reader)
 	if err != nil {
 		return "", err
 	}
@@ -368,6 +369,6 @@ func updateSessionValue(session *sessions.Session, key, value string) error {
 		return err
 	}
 
-	session.Values[key] = b.String()
+	session.Values[key] = base64.StdEncoding.EncodeToString(b.Bytes())
 	return nil
 }

--- a/gothic/gothic_test.go
+++ b/gothic/gothic_test.go
@@ -3,6 +3,7 @@ package gothic_test
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/base64"
 	"fmt"
 	"html"
 	"io/ioutil"
@@ -274,12 +275,13 @@ func gzipString(value string) string {
 		return "err"
 	}
 
-	return b.String()
+	return base64.StdEncoding.EncodeToString(b.Bytes())
 }
 
 func ungzipString(value string) string {
 	rdata := strings.NewReader(value)
-	r, err := gzip.NewReader(rdata)
+	b64Reader := base64.NewDecoder(base64.StdEncoding, rdata)
+	r, err := gzip.NewReader(b64Reader)
 	if err != nil {
 		return "err"
 	}


### PR DESCRIPTION
`string(gzippedData)` does not guarantee a UTF-8 sanitized string, which may lead to corrupted data.

Also, returned the non-nil error from `GetFromSession` to make debugging easier and changed the test file to also encode the test data into base64.

I was getting `gzip: invalid header` in my app and upon inspection found the sequence `239 191 189` repeated many times across the gzipped data, including in the gzip header.