### PR TITLE
fix: fall back to userPrincipalName when mail is empty in AzureADv2

### DIFF
--- a/providers/azureadv2/azureadv2.go
+++ b/providers/azureadv2/azureadv2.go
@@ -208,6 +208,9 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	}
 
 	user.Email = u.Email
+	if user.Email == "" {
+		user.Email = u.UserPrincipalName
+	}
 	user.Name = u.DisplayName
 	user.FirstName = u.FirstName
 	user.LastName = u.LastName


### PR DESCRIPTION
Fixes #289

## Problem

The AzureADv2 provider maps `user.Email` from the Microsoft Graph API `mail` field. However, many Azure AD accounts (especially personal Microsoft accounts and some organizational accounts) have `mail` as null/empty while `userPrincipalName` contains their email address.

This results in an empty `Email` field on the returned user.

## Fix

Fall back to `userPrincipalName` when `mail` is empty:

```go
user.Email = u.Email
if user.Email == "" {
    user.Email = u.UserPrincipalName
}
```

This matches the approach used by other OAuth providers (e.g., Google) that check multiple fields for email.