### PR TITLE
fix(vk): tolerate accounts without email (#338)

### DIFF
--- a/providers/vk/authorize_internal_test.go
+++ b/providers/vk/authorize_internal_test.go
@@ -1,0 +1,68 @@
+package vk
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// tokenServer spins up an httptest.Server that responds to the OAuth2 token
+// exchange with the given JSON body, and swaps the package-level tokenURL so
+// the provider hits it. The returned cleanup restores the original tokenURL
+// and shuts the server down.
+func tokenServer(t *testing.T, body string) func() {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	original := tokenURL
+	tokenURL = server.URL
+	return func() {
+		tokenURL = original
+		server.Close()
+	}
+}
+
+func TestAuthorize_PopulatesEmailWhenPresent(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	cleanup := tokenServer(t, `{"access_token":"tok","expires_in":86400,"user_id":1,"email":"user@example.com"}`)
+	defer cleanup()
+
+	p := New("key", "secret", "/cb")
+	sess, err := p.BeginAuth("state")
+	a.NoError(err)
+	s := sess.(*Session)
+
+	token, err := s.Authorize(p, url.Values{"code": {"any"}})
+	a.NoError(err)
+	a.Equal("tok", token)
+	a.Equal("user@example.com", s.email)
+}
+
+func TestAuthorize_NoErrorWhenEmailMissing(t *testing.T) {
+	// Regression test for markbates/goth#338: VK accounts created without an
+	// email field omit "email" from the token response. The provider must
+	// treat it as optional and not fail the auth flow.
+	t.Parallel()
+	a := assert.New(t)
+
+	cleanup := tokenServer(t, `{"access_token":"tok","expires_in":86400,"user_id":1}`)
+	defer cleanup()
+
+	p := New("key", "secret", "/cb")
+	sess, err := p.BeginAuth("state")
+	a.NoError(err)
+	s := sess.(*Session)
+
+	token, err := s.Authorize(p, url.Values{"code": {"any"}})
+	a.NoError(err)
+	a.Equal("tok", token)
+	a.Equal("", s.email)
+}

--- a/providers/vk/session.go
+++ b/providers/vk/session.go
@@ -43,14 +43,15 @@ func (s *Session) Authorize(provider goth.Provider, params goth.Params) (string,
 		return "", errors.New("Invalid token received from provider")
 	}
 
-	email, ok := token.Extra("email").(string)
-	if !ok {
-		return "", errors.New("Cannot fetch user email")
-	}
-
 	s.AccessToken = token.AccessToken
 	s.ExpiresAt = token.Expiry
-	s.email = email
+	// VK returns "email" as a top-level field in the token response only when the
+	// user has an email set in their profile AND has granted the email scope.
+	// Accounts registered without an email (allowed by VK since ~2018) omit it,
+	// so treat it as optional rather than failing the entire login flow (#338).
+	if email, ok := token.Extra("email").(string); ok {
+		s.email = email
+	}
 	return s.AccessToken, err
 }
 


### PR DESCRIPTION
## What

Closes #338.

VK's OAuth2 token endpoint omits the top-level `email` field when the user has no email in their VK profile (VK has allowed registration without email since ~2018). The current code treats this as a fatal error:

```go
email, ok := token.Extra("email").(string)
if !ok {
    return "", errors.New("Cannot fetch user email")
}
```

…which means accounts without an email can't complete OAuth at all.

## Change

Make `email` optional in `providers/vk/session.go`:

```go
if email, ok := token.Extra("email").(string); ok {
    s.email = email
}
```

- Accounts **with** email: unchanged — `Session.email` is populated and propagated to `goth.User.Email`.
- Accounts **without** email: no longer fail; `goth.User.Email` is empty, matching the contract already used by providers like Twitter where email is opt-in.

## Backward compatibility

The original issue author (@nikita-vanyasin) wondered whether fixing this in-place would break existing users. In practice it cannot: the only callers affected are those that were already getting `"Cannot fetch user email"` and thus already broken. Callers that received an email continue to receive it.

If a downstream caller really needs to *enforce* an email, they can already do so by checking `user.Email == ""` after `gothic.CompleteUserAuth` — which is the standard pattern for optional-email providers.

## Tests

Added `providers/vk/authorize_internal_test.go` with two subtests using `httptest.Server` to mock the token endpoint:

- `TestAuthorize_PopulatesEmailWhenPresent` — happy path, regression-guards existing behaviour.
- `TestAuthorize_NoErrorWhenEmailMissing` — fails on master, passes with this fix.

Verified locally: the new regression test fails when the patch is reverted and passes with it applied. Full `go test ./...` is green; `go vet ./...` is clean.