### PR TITLE
fix(discord): always include identify scope (#414)

### DIFF
--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -205,15 +205,17 @@ func newConfig(p *Provider, scopes []string) *oauth2.Config {
 			AuthURL:  authURL,
 			TokenURL: tokenURL,
 		},
-		Scopes: []string{},
+		// `identify` gates /users/@me itself; supplementary scopes like
+		// `email` only enrich its response. Always include it so callers
+		// who request just `email` (or any other scope) still get a usable
+		// user-fetch flow instead of a 401 from FetchUser (#414).
+		Scopes: []string{ScopeIdentify},
 	}
 
-	if len(scopes) > 0 {
-		for _, scope := range scopes {
+	for _, scope := range scopes {
+		if scope != ScopeIdentify {
 			c.Scopes = append(c.Scopes, scope)
 		}
-	} else {
-		c.Scopes = []string{ScopeIdentify}
 	}
 
 	return c

--- a/providers/discord/discord_test.go
+++ b/providers/discord/discord_test.go
@@ -40,6 +40,50 @@ func Test_BeginAuth(t *testing.T) {
 	a.Contains(s.AuthURL, "discord.com/api/oauth2/authorize")
 }
 
+func Test_DefaultScopeAlwaysIncludesIdentify(t *testing.T) {
+	// Regression test for #414: passing any custom scope (e.g. only "email")
+	// used to drop ScopeIdentify from the OAuth2 config, which caused Discord
+	// to return 401 on /users/@me — so FetchUser failed for everyone who
+	// hadn't explicitly listed "identify". ScopeIdentify must always be in
+	// the scope list, and never duplicated when the caller passes it.
+	t.Parallel()
+	a := assert.New(t)
+
+	cases := []struct {
+		name   string
+		scopes []string
+		want   []string
+	}{
+		{
+			name:   "no scopes",
+			scopes: nil,
+			want:   []string{ScopeIdentify},
+		},
+		{
+			name:   "email only",
+			scopes: []string{ScopeEmail},
+			want:   []string{ScopeIdentify, ScopeEmail},
+		},
+		{
+			name:   "identify explicit (no dupe)",
+			scopes: []string{ScopeIdentify, ScopeEmail},
+			want:   []string{ScopeIdentify, ScopeEmail},
+		},
+		{
+			name:   "multiple custom",
+			scopes: []string{ScopeEmail, ScopeConnections, ScopeGuilds},
+			want:   []string{ScopeIdentify, ScopeEmail, ScopeConnections, ScopeGuilds},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New("k", "s", "/cb", tc.scopes...)
+			a.Equal(tc.want, p.config.Scopes, tc.name)
+		})
+	}
+}
+
 func Test_SessionFromJSON(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)


### PR DESCRIPTION
## What

Closes #414.

`providers/discord/discord.go:newConfig` currently drops `ScopeIdentify` whenever the caller passes any custom scope:

```go
if len(scopes) > 0 {
    for _, scope := range scopes {
        c.Scopes = append(c.Scopes, scope)
    }
} else {
    c.Scopes = []string{ScopeIdentify}
}
```

So calling `discord.New(k, s, cb, "email")` yields `Scopes: ["email"]`, which Discord rejects with `401` from `/users/@me`. The reporter (@tardisx) hit this exact path.

Discord's docs are explicit: `identify` is the scope that gates `/users/@me` itself; `email` only enriches the response. The existing constant in this file even spells it out:

```go
// ScopeIdentify allows /users/@me without email
// ScopeEmail enables /users/@me to return an email
```

## Change

Always include `ScopeIdentify` first, then append user scopes while filtering out a duplicate `identify`:

```go
Scopes: []string{ScopeIdentify},
...
for _, scope := range scopes {
    if scope != ScopeIdentify {
        c.Scopes = append(c.Scopes, scope)
    }
}
```

## Backward compatibility

- Callers passing no scopes: unchanged — `[identify]`.
- Callers passing `[identify, ...]`: unchanged — order preserved, no duplication.
- Callers passing scopes without `identify` (e.g. `[email]`): now `[identify, email]` instead of `[email]`. Their previously-broken `FetchUser` call now succeeds. The only behavioural difference is that Discord's consent screen will list `identify` — which is correct, since the app was already trying to read user info.

## Tests

Added `Test_DefaultScopeAlwaysIncludesIdentify` — table-driven, four cases:

| name | input scopes | expected `config.Scopes` |
|---|---|---|
| no scopes | `nil` | `[identify]` |
| email only | `[email]` | `[identify, email]` |
| identify explicit (no dupe) | `[identify, email]` | `[identify, email]` |
| multiple custom | `[email, connections, guilds]` | `[identify, email, connections, guilds]` |

Verified the new test fails on master (cases 2 and 4 explicitly miss `identify`) and passes with the fix applied. `go test ./...` is green across all 50+ providers; `go vet ./...` is clean.