### PR TITLE
fix(auth0): map given_name/family_name to User (#430)

### DIFF
--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -37,6 +37,8 @@ type auth0UserResp struct {
 	Email     string `json:"email"`
 	UserID    string `json:"sub"`
 	AvatarURL string `json:"picture"`
+	FirstName string `json:"given_name"`
+	LastName  string `json:"family_name"`
 }
 
 // New creates a new Auth0 provider and sets up important connection details.
@@ -162,6 +164,8 @@ func userFromReader(r io.Reader, user *goth.User) error {
 	user.NickName = u.NickName
 	user.UserID = u.UserID
 	user.AvatarURL = u.AvatarURL
+	user.FirstName = u.FirstName
+	user.LastName = u.LastName
 	user.RawData = rawData
 	return nil
 }

--- a/providers/auth0/auth0_test.go
+++ b/providers/auth0/auth0_test.go
@@ -65,7 +65,9 @@ func Test_FetchUser(t *testing.T) {
   		"email": "test.account@userinfo.com",
   		"clientID": "q2hnj2iu...",
   		"updated_at": "2016-12-05T15:15:40.545Z",
-  		"name": "test.account@userinfo.com",
+  		"name": "Test User",
+  		"given_name": "Test",
+  		"family_name": "User",
   		"picture": "https://s.gravatar.com/avatar/dummy.png",
   		"user_id": "auth0|58454...",
   		"nickname": "test.account",
@@ -91,9 +93,16 @@ func Test_FetchUser(t *testing.T) {
 	a.Equal(u.Email, "test.account@userinfo.com")
 	a.Equal(u.UserID, "auth0|58454...")
 	a.Equal(u.NickName, "test.account")
-	a.Equal(u.Name, "test.account@userinfo.com")
+	a.Equal(u.Name, "Test User")
+	// Auth0 returns OIDC-standard given_name/family_name claims (#430) — they
+	// should populate goth.User.FirstName/LastName, matching how the Google
+	// provider handles the same claims.
+	a.Equal("Test", u.FirstName)
+	a.Equal("User", u.LastName)
 	a.Equal("token", u.AccessToken)
-
+	// email_verified isn't mapped to a typed field but must remain in RawData
+	// so callers that need it can still read it.
+	a.Equal(false, u.RawData["email_verified"])
 }
 
 func provider() *auth0.Provider {


### PR DESCRIPTION
## What

Closes #430.

`providers/auth0/auth0.go:userFromReader` only extracted a subset of the OIDC claims returned by Auth0's `/userinfo` endpoint:

```go
type auth0UserResp struct {
    Name      string `json:"name"`
    NickName  string `json:"nickname"`
    Email     string `json:"email"`
    UserID    string `json:"sub"`
    AvatarURL string `json:"picture"`
}
```

`given_name` and `family_name` — standard OIDC claims that Auth0 returns alongside `name`/`email`/`sub` — were silently dropped, even though `goth.User` has `FirstName` and `LastName` fields ready for them. The reporter (@justman00) hit this while wiring Auth0 to a `goth.User` consumer.

## Change

Add the two fields to `auth0UserResp` and map them in `userFromReader`. Matches how the Google provider already handles the same OIDC claims (`providers/google/google.go:googleUser`):

```go
FirstName string `json:"given_name"`
LastName  string `json:"family_name"`
```

```go
user.FirstName = u.FirstName
user.LastName  = u.LastName
```

## Scope

The reporter also listed `email_verified`, `locale`, and `updated_at` as unmapped. None of these has a typed slot on `goth.User` (no `EmailVerified`, no `Locale`), so promoting them to typed fields would require adding fields to the shared `goth.User` struct — out of scope for an Auth0-specific bug fix, and visible to every provider. Those claims already land in `user.RawData` and remain readable from there. I added an assertion to `Test_FetchUser` to lock that contract in so future refactors don't silently drop them.

## Backward compatibility

Strictly additive — no existing field's mapping is touched. Callers that read `user.FirstName` / `user.LastName` from Auth0 used to get empty strings and now get the real values. Callers that don't read them are unaffected.

## Tests

Extended `Test_FetchUser` to:
1. Include `given_name`/`family_name` in the sample `/userinfo` response.
2. Differentiate `name` from `given_name`/`family_name` so each assertion exercises a distinct claim (the existing sample used the email address for `name`, which hid this exact class of bug).
3. Assert `u.FirstName == "Test"`, `u.LastName == "User"`.
4. Assert `u.RawData["email_verified"] == false` to lock the RawData fallback contract.

Verified the new assertions fail on master (`FirstName`/`LastName` come back empty), pass with the fix applied. Full `go test ./...` is green across all 50+ providers; `go vet ./...` is clean.