### PR TITLE
Preconfigurable providers

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -9,6 +9,10 @@ import (
 	"golang.org/x/oauth2"
 )
 
+type ProviderConfig interface {
+	Build() Provider
+}
+
 // Provider needs to be implemented for each 3rd party authentication provider
 // e.g. Facebook, Twitter, etc...
 type Provider interface {

--- a/provider.go
+++ b/provider.go
@@ -23,8 +23,9 @@ type Provider interface {
 }
 
 type ProviderConfig interface {
-	Build() Provider
+	Name() string
 	SetCallbackURL(string)
+	Build() Provider
 }
 
 const NoAuthUrlErrorMessage = "an AuthURL has not been set"

--- a/provider.go
+++ b/provider.go
@@ -9,10 +9,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type ProviderConfig interface {
-	Build() Provider
-}
-
 // Provider needs to be implemented for each 3rd party authentication provider
 // e.g. Facebook, Twitter, etc...
 type Provider interface {
@@ -24,6 +20,11 @@ type Provider interface {
 	Debug(bool)
 	RefreshToken(refreshToken string) (*oauth2.Token, error) // Get new access token based on the refresh token
 	RefreshTokenAvailable() bool                             // Refresh token is provided by auth provider or not
+}
+
+type ProviderConfig interface {
+	Build() Provider
+	SetCallbackURL(string)
 }
 
 const NoAuthUrlErrorMessage = "an AuthURL has not been set"

--- a/provider_test.go
+++ b/provider_test.go
@@ -42,6 +42,7 @@ func Test_ConfigProvider(t *testing.T) {
 		cfg.SetCallbackURL(callbackURL)
 		provider := cfg.Build()
 		providers = append(providers, provider)
+		a.Equal(cfg.Name(), provider.Name())
 		goth.UseProviders(provider)
 	}
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,12 +1,36 @@
 package goth_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/azureadv2"
 	"github.com/markbates/goth/providers/faux"
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_ConfigProvider(t *testing.T) {
+	a := assert.New(t)
+	providerCfg := azureadv2.Config{
+		ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
+		Secret:    "foo",
+	}
+	callbackURL := "http://localhost:3000"
+	providerCfg.CallbackURL = callbackURL
+	provider := providerCfg.Build()
+	goth.UseProviders(provider)
+
+	a.Equal(len(goth.GetProviders()), 1)
+	a.Equal(goth.GetProviders()[provider.Name()], provider)
+
+	// Gets provider, reflect the underlying azureadv2.Provider and
+	// compares it's callbackURL with the one that was set in azureadv2.Config
+	v := reflect.ValueOf(goth.GetProviders()[provider.Name()]).Elem()
+	a.Equal(v.FieldByName("CallbackURL").String(), callbackURL)
+
+	goth.ClearProviders()
+}
 
 func Test_UseProviders(t *testing.T) {
 	a := assert.New(t)

--- a/provider_test.go
+++ b/provider_test.go
@@ -5,29 +5,71 @@ import (
 	"testing"
 
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/apple"
 	"github.com/markbates/goth/providers/azureadv2"
 	"github.com/markbates/goth/providers/faux"
+	"github.com/markbates/goth/providers/github"
+	"github.com/markbates/goth/providers/tiktok"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_ConfigProvider(t *testing.T) {
 	a := assert.New(t)
-	providerCfg := azureadv2.Config{
-		ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
-		Secret:    "foo",
+
+	configs := []goth.ProviderConfig{
+		&azureadv2.Config{
+			ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
+			Secret:    "foo",
+		},
+		&github.Config{
+			ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
+			Secret:    "foo",
+		},
+		&tiktok.Config{
+			ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
+			Secret:    "foo",
+		},
+		&apple.Config{
+			ClientId: "6731de76-14a6-49ae-97bc-6eba6914391e",
+			Secret:   "foo",
+		},
 	}
-	callbackURL := "http://localhost:3000"
-	providerCfg.CallbackURL = callbackURL
-	provider := providerCfg.Build()
-	goth.UseProviders(provider)
 
-	a.Equal(len(goth.GetProviders()), 1)
-	a.Equal(goth.GetProviders()[provider.Name()], provider)
+	callbackURL := "http://localhost:3000/{provider}/callback"
 
-	// Gets provider, reflect the underlying azureadv2.Provider and
-	// compares it's callbackURL with the one that was set in azureadv2.Config
-	v := reflect.ValueOf(goth.GetProviders()[provider.Name()]).Elem()
-	a.Equal(v.FieldByName("CallbackURL").String(), callbackURL)
+	var providers []goth.Provider
+	for _, cfg := range configs {
+		cfg.SetCallbackURL(callbackURL)
+		provider := cfg.Build()
+		providers = append(providers, provider)
+		goth.UseProviders(provider)
+	}
+
+	a.Equal(len(goth.GetProviders()), len(configs))
+
+	fieldNames := []string{
+		"CallbackURL", "callbackURL",
+		"RedirectURL", "redirectURL",
+		"RedirectURI", "redirectURI",
+	}
+	for _, provider := range providers {
+		a.Equal(goth.GetProviders()[provider.Name()], provider)
+		// Gets provider, reflect the underlying azureadv2.Provider and
+		// compares it's callbackURL with the one that was set in azureadv2.Config
+		v := reflect.ValueOf(goth.GetProviders()[provider.Name()]).Elem()
+		fieldFound := false
+		for _, fieldName := range fieldNames {
+			f := v.FieldByName(fieldName)
+			if f.IsValid() {
+				fieldFound = true
+				a.Equal(f.String(), callbackURL)
+				break
+			}
+		}
+		if !fieldFound {
+			t.Fatal("callback/redirect field was not found for " + provider.Name())
+		}
+	}
 
 	goth.ClearProviders()
 }

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Amazon provider and sets up important connection details.
 // You should always call `amazon.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "amazon"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/apple/apple.go
+++ b/providers/apple/apple.go
@@ -39,6 +39,20 @@ type Provider struct {
 	timeNowFn            func() time.Time
 }
 
+type Config struct {
+	ClientId    string
+	Secret      string
+	RedirectURL string
+	HttpClient  *http.Client
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientId, c.Secret, c.RedirectURL, c.HttpClient, c.Scopes...)
+}
+
+// clientId, secret, redirectURL string, httpClient *http.Client, scopes ...string)
+
 func New(clientId, secret, redirectURL string, httpClient *http.Client, scopes ...string) *Provider {
 	p := &Provider{
 		clientId:     clientId,

--- a/providers/apple/apple.go
+++ b/providers/apple/apple.go
@@ -47,7 +47,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.RedirectURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientId, c.Secret, c.RedirectURL, c.HttpClient, c.Scopes...)
 }
 

--- a/providers/apple/apple.go
+++ b/providers/apple/apple.go
@@ -47,6 +47,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "apple"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.RedirectURL = url
 }

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -31,6 +31,18 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Auth0Domain string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Auth0Domain, c.Scopes...)
+}
+
 type auth0UserResp struct {
 	Name      string `json:"name"`
 	NickName  string `json:"nickname"`

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -39,7 +39,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Auth0Domain, c.Scopes...)
 }
 

--- a/providers/auth0/auth0.go
+++ b/providers/auth0/auth0.go
@@ -39,6 +39,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "auth0"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/azuread/azuread.go
+++ b/providers/azuread/azuread.go
@@ -52,6 +52,18 @@ type Provider struct {
 	resources    []string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Resources   []string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Resources, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/azuread/azuread.go
+++ b/providers/azuread/azuread.go
@@ -60,6 +60,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "azuread"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/azuread/azuread.go
+++ b/providers/azuread/azuread.go
@@ -60,7 +60,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Resources, c.Scopes...)
 }
 

--- a/providers/azureadv2/azureadv2.go
+++ b/providers/azureadv2/azureadv2.go
@@ -49,6 +49,10 @@ type Config struct {
 	Opts        ProviderOptions
 }
 
+func (c *Config) Name() string {
+	return "azureadv2"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/azureadv2/azureadv2.go
+++ b/providers/azureadv2/azureadv2.go
@@ -49,7 +49,11 @@ type Config struct {
 	Opts        ProviderOptions
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Opts)
 }
 

--- a/providers/azureadv2/azureadv2.go
+++ b/providers/azureadv2/azureadv2.go
@@ -42,6 +42,17 @@ type (
 	}
 )
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Opts        ProviderOptions
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Opts)
+}
+
 // These are the well known Azure AD Tenants. These are not an exclusive list of all Tenants
 //
 // See also https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints

--- a/providers/battlenet/battlenet.go
+++ b/providers/battlenet/battlenet.go
@@ -36,6 +36,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "battlenet"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/battlenet/battlenet.go
+++ b/providers/battlenet/battlenet.go
@@ -36,7 +36,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/battlenet/battlenet.go
+++ b/providers/battlenet/battlenet.go
@@ -29,6 +29,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Battle.net provider and sets up important connection details.
 // You should always call `battlenet.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -73,6 +73,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "bitbucket"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -73,7 +73,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/bitbucket/bitbucket.go
+++ b/providers/bitbucket/bitbucket.go
@@ -66,6 +66,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/bitly/bitly.go
+++ b/providers/bitly/bitly.go
@@ -43,6 +43,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Ensure `bitly.Provider` implements `goth.Provider`.
 var _ goth.Provider = &Provider{}
 

--- a/providers/bitly/bitly.go
+++ b/providers/bitly/bitly.go
@@ -50,7 +50,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/bitly/bitly.go
+++ b/providers/bitly/bitly.go
@@ -50,6 +50,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "bitly"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -28,6 +28,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Box provider and sets up important connection details.
 // You should always call `box.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -35,6 +35,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "box"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/box/box.go
+++ b/providers/box/box.go
@@ -35,7 +35,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/classlink/provider.go
+++ b/providers/classlink/provider.go
@@ -30,7 +30,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/classlink/provider.go
+++ b/providers/classlink/provider.go
@@ -23,6 +23,17 @@ type Provider struct {
 	config       *oauth2.Config
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	prov := &Provider{
 		ClientKey:    clientKey,

--- a/providers/classlink/provider.go
+++ b/providers/classlink/provider.go
@@ -30,6 +30,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "classlink"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -36,6 +36,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "cloudfoundry"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -28,6 +28,18 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	UaaURL      string
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.UaaURL, c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Cloud Foundry provider and sets up important connection details.
 // You should always call `cloudfoundry.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/cloudfoundry/cf.go
+++ b/providers/cloudfoundry/cf.go
@@ -36,7 +36,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.UaaURL, c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/cognito/cognito.go
+++ b/providers/cognito/cognito.go
@@ -46,6 +46,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "cognito"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/cognito/cognito.go
+++ b/providers/cognito/cognito.go
@@ -38,6 +38,18 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientID    string
+	Secret      string
+	BaseUrl     string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientID, c.Secret, c.BaseUrl, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new AWS Cognito provider and sets up important connection details.
 // You should always call `cognito.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/cognito/cognito.go
+++ b/providers/cognito/cognito.go
@@ -46,7 +46,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientID, c.Secret, c.BaseUrl, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Dailymotion provider and sets up important connection details.
 // You should always call `dailymotion.New` to get a new provider. Never try to
 // create one manually.

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/dailymotion/dailymotion.go
+++ b/providers/dailymotion/dailymotion.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "dailymotion"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -39,7 +39,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -32,6 +32,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Deezer provider and sets up important connection details.
 // You should always call `deezer.New` to get a new provider. Never try to
 // create one manually.

--- a/providers/deezer/deezer.go
+++ b/providers/deezer/deezer.go
@@ -39,6 +39,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "deezer"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -51,7 +51,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -44,6 +44,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 var _ goth.Provider = &Provider{}
 
 // Name is the name used to retrieve this provider later.

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -51,6 +51,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "digitalocean"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/dingtalk/dingtalk.go
+++ b/providers/dingtalk/dingtalk.go
@@ -120,6 +120,18 @@ type Provider struct {
 	expectedCorpID string // Corporate ID to validate against for company-specific authentication
 }
 
+type Config struct {
+	ClientKey      string
+	Secret         string
+	CallbackURL    string
+	ExpectedCorpID string
+	Scopes         []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.ExpectedCorpID, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/dingtalk/dingtalk.go
+++ b/providers/dingtalk/dingtalk.go
@@ -128,6 +128,10 @@ type Config struct {
 	Scopes         []string
 }
 
+func (c *Config) Name() string {
+	return "dingtalk"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/dingtalk/dingtalk.go
+++ b/providers/dingtalk/dingtalk.go
@@ -128,7 +128,11 @@ type Config struct {
 	Scopes         []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.ExpectedCorpID, c.Scopes...)
 }
 

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -72,7 +72,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -65,6 +65,17 @@ type Provider struct {
 	permissions  string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name gets the name used to retrieve this provider.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/discord/discord.go
+++ b/providers/discord/discord.go
@@ -72,6 +72,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "discord"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -31,6 +31,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Session stores data during the auth process with Dropbox.
 type Session struct {
 	AuthURL string

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -38,7 +38,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/dropbox/dropbox.go
+++ b/providers/dropbox/dropbox.go
@@ -38,6 +38,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "dropbox"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/eveonline/eveonline.go
+++ b/providers/eveonline/eveonline.go
@@ -36,6 +36,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "eveonline"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/eveonline/eveonline.go
+++ b/providers/eveonline/eveonline.go
@@ -36,7 +36,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/eveonline/eveonline.go
+++ b/providers/eveonline/eveonline.go
@@ -29,6 +29,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Eve Online provider and sets up important connection details.
 // You should always call `eveonline.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -58,7 +58,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -51,6 +51,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -58,6 +58,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "facebook"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -70,7 +70,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -63,6 +63,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/fitbit/fitbit.go
+++ b/providers/fitbit/fitbit.go
@@ -70,6 +70,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "fitbit"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/gitea/gitea.go
+++ b/providers/gitea/gitea.go
@@ -48,6 +48,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "gitea"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/gitea/gitea.go
+++ b/providers/gitea/gitea.go
@@ -41,6 +41,17 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Gitea provider and sets up important connection details.
 // You should always call `gitea.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/gitea/gitea.go
+++ b/providers/gitea/gitea.go
@@ -48,7 +48,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -77,7 +77,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -70,6 +70,17 @@ type Provider struct {
 	emailURL     string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -77,6 +77,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "github"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -49,7 +49,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -42,6 +42,17 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Gitlab provider and sets up important connection details.
 // You should always call `gitlab.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/gitlab/gitlab.go
+++ b/providers/gitlab/gitlab.go
@@ -49,6 +49,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "gitlab"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -53,6 +53,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "google"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -53,7 +53,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -46,6 +46,17 @@ type Provider struct {
 	providerName    string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -35,6 +35,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "heroku"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -35,7 +35,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/heroku/heroku.go
+++ b/providers/heroku/heroku.go
@@ -28,6 +28,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Heroku provider and sets up important connection details.
 // You should always call `heroku.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/hubspot/hubspot.go
+++ b/providers/hubspot/hubspot.go
@@ -48,6 +48,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Hubspot provider and sets up important connection details.
 // You should always call `hubspot.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/hubspot/hubspot.go
+++ b/providers/hubspot/hubspot.go
@@ -55,6 +55,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "hubspot"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/hubspot/hubspot.go
+++ b/providers/hubspot/hubspot.go
@@ -55,7 +55,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -82,7 +82,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -82,6 +82,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "influxcloud"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/influxcloud/influxcloud.go
+++ b/providers/influxcloud/influxcloud.go
@@ -75,6 +75,17 @@ type Provider struct {
 	providerName    string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -46,6 +46,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -53,7 +53,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -53,6 +53,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "instagram"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -49,7 +49,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -49,6 +49,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "intercom"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/intercom/intercom.go
+++ b/providers/intercom/intercom.go
@@ -42,6 +42,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/kakao/kakao.go
+++ b/providers/kakao/kakao.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "kakao"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/kakao/kakao.go
+++ b/providers/kakao/kakao.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/kakao/kakao.go
+++ b/providers/kakao/kakao.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Kakao provider and sets up important connection details.
 // You should always call `kakao.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/lark/lark.go
+++ b/providers/lark/lark.go
@@ -41,6 +41,17 @@ type Provider struct {
 	appAccessToken *appAccessToken
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Lark provider and sets up important connection details.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{

--- a/providers/lark/lark.go
+++ b/providers/lark/lark.go
@@ -48,6 +48,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "lark"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/lark/lark.go
+++ b/providers/lark/lark.go
@@ -48,7 +48,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -51,6 +51,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "lastfm"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -45,6 +45,16 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/lastfm/lastfm.go
+++ b/providers/lastfm/lastfm.go
@@ -51,7 +51,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL)
 }
 

--- a/providers/line/line.go
+++ b/providers/line/line.go
@@ -37,6 +37,17 @@ type Provider struct {
 	providerName    string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Line provider and sets up important connection details.
 // You should always call `line.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/line/line.go
+++ b/providers/line/line.go
@@ -44,7 +44,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/line/line.go
+++ b/providers/line/line.go
@@ -44,6 +44,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "line"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -58,7 +58,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -58,6 +58,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "linkedin"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -51,6 +51,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/mailru/mailru.go
+++ b/providers/mailru/mailru.go
@@ -55,6 +55,10 @@ type Config struct {
 	Scopes       []string
 }
 
+func (c *Config) Name() string {
+	return "mailru"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.RedirectURL = url
 }

--- a/providers/mailru/mailru.go
+++ b/providers/mailru/mailru.go
@@ -48,6 +48,17 @@ type Provider struct {
 	oauthConfig *oauth2.Config
 }
 
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	Scopes       []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientID, c.ClientSecret, c.RedirectURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.name

--- a/providers/mailru/mailru.go
+++ b/providers/mailru/mailru.go
@@ -55,7 +55,11 @@ type Config struct {
 	Scopes       []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.RedirectURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientID, c.ClientSecret, c.RedirectURL, c.Scopes...)
 }
 

--- a/providers/mastodon/mastodon.go
+++ b/providers/mastodon/mastodon.go
@@ -39,7 +39,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/mastodon/mastodon.go
+++ b/providers/mastodon/mastodon.go
@@ -32,6 +32,17 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Mastodon provider and sets up important connection details.
 // You should always call `mastodon.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/mastodon/mastodon.go
+++ b/providers/mastodon/mastodon.go
@@ -39,6 +39,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "mastodon"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/meetup/meetup.go
+++ b/providers/meetup/meetup.go
@@ -53,6 +53,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "meetup"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/meetup/meetup.go
+++ b/providers/meetup/meetup.go
@@ -46,6 +46,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/meetup/meetup.go
+++ b/providers/meetup/meetup.go
@@ -53,7 +53,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/microsoftonline/microsoftonline.go
+++ b/providers/microsoftonline/microsoftonline.go
@@ -56,7 +56,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/microsoftonline/microsoftonline.go
+++ b/providers/microsoftonline/microsoftonline.go
@@ -49,6 +49,17 @@ type Provider struct {
 	tenant       string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/microsoftonline/microsoftonline.go
+++ b/providers/microsoftonline/microsoftonline.go
@@ -56,6 +56,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "microsoftonline"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/naver/naver.go
+++ b/providers/naver/naver.go
@@ -27,6 +27,16 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/naver/naver.go
+++ b/providers/naver/naver.go
@@ -33,6 +33,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "naver"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/naver/naver.go
+++ b/providers/naver/naver.go
@@ -33,7 +33,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL)
 }
 

--- a/providers/nextcloud/nextcloud.go
+++ b/providers/nextcloud/nextcloud.go
@@ -35,6 +35,17 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New is only here to fulfill the interface requirements and does not work properly without
 // setting your own Nextcloud connect parameters, more precisely AuthURL, TokenURL and ProfileURL.
 // Please use NewCustomisedDNS with the beginning of your URL or NewCustomiseURL.

--- a/providers/nextcloud/nextcloud.go
+++ b/providers/nextcloud/nextcloud.go
@@ -42,6 +42,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "nextcloud"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/nextcloud/nextcloud.go
+++ b/providers/nextcloud/nextcloud.go
@@ -42,7 +42,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/okta/okta.go
+++ b/providers/okta/okta.go
@@ -33,7 +33,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientID, c.Secret, c.OrgURL, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/okta/okta.go
+++ b/providers/okta/okta.go
@@ -33,6 +33,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "okta"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/okta/okta.go
+++ b/providers/okta/okta.go
@@ -25,6 +25,18 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientID    string
+	Secret      string
+	OrgURL      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientID, c.Secret, c.OrgURL, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Okta provider and sets up important connection details.
 // You should always call `okta.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "onedrive"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/onedrive/onedrive.go
+++ b/providers/onedrive/onedrive.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Onedrive provider and sets up important connection details.
 // You should always call `onedrive.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -80,6 +80,10 @@ type Config struct {
 	Scopes                 []string
 }
 
+func (c *Config) Name() string {
+	return "openid-connect"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -80,8 +80,16 @@ type Config struct {
 	Scopes                 []string
 }
 
-func (c Config) Build() (*Provider, error) {
-	return New(c.ClientKey, c.Secret, c.CallbackURL, c.OpenIDAutoDiscoveryURL, c.Scopes...)
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
+	provider, err := New(c.ClientKey, c.Secret, c.CallbackURL, c.OpenIDAutoDiscoveryURL, c.Scopes...)
+	if err != nil {
+		panic(err)
+	}
+	return provider
 }
 
 type OpenIDConfig struct {

--- a/providers/openidConnect/openidConnect.go
+++ b/providers/openidConnect/openidConnect.go
@@ -72,6 +72,18 @@ type Provider struct {
 	SkipUserInfoRequest bool
 }
 
+type Config struct {
+	ClientKey              string
+	Secret                 string
+	CallbackURL            string
+	OpenIDAutoDiscoveryURL string
+	Scopes                 []string
+}
+
+func (c Config) Build() (*Provider, error) {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.OpenIDAutoDiscoveryURL, c.Scopes...)
+}
+
 type OpenIDConfig struct {
 	AuthEndpoint     string `json:"authorization_endpoint"`
 	TokenEndpoint    string `json:"token_endpoint"`

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -57,6 +57,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "oura"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -57,7 +57,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/oura/oura.go
+++ b/providers/oura/oura.go
@@ -50,6 +50,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/patreon/patreon.go
+++ b/providers/patreon/patreon.go
@@ -87,6 +87,17 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name gets the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/patreon/patreon.go
+++ b/providers/patreon/patreon.go
@@ -94,7 +94,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/patreon/patreon.go
+++ b/providers/patreon/patreon.go
@@ -94,6 +94,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "patreon"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -41,6 +41,17 @@ type Provider struct {
 	profileURL   string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Paypal provider and sets up important connection details.
 // You should always call `paypal.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -48,7 +48,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/paypal/paypal.go
+++ b/providers/paypal/paypal.go
@@ -48,6 +48,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "paypal"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/reddit/reddit.go
+++ b/providers/reddit/reddit.go
@@ -24,6 +24,20 @@ type Provider struct {
 	userURL string
 }
 
+type Config struct {
+	ClientID      string
+	ClientSecret  string
+	RedirectURI   string
+	Duration      string
+	TokenEndpoint string
+	UserURL       string
+	Scopes        []string
+}
+
+func (c Config) Build() Provider {
+	return New(c.ClientID, c.ClientSecret, c.RedirectURI, c.Duration, c.TokenEndpoint, c.UserURL, c.Scopes...)
+}
+
 func New(clientID string, clientSecret string, redirectURI string, duration string, tokenEndpoint string, userURL string, scopes ...string) Provider {
 	return Provider{
 		providerName: "reddit",

--- a/providers/reddit/reddit.go
+++ b/providers/reddit/reddit.go
@@ -34,8 +34,13 @@ type Config struct {
 	Scopes        []string
 }
 
-func (c Config) Build() Provider {
-	return New(c.ClientID, c.ClientSecret, c.RedirectURI, c.Duration, c.TokenEndpoint, c.UserURL, c.Scopes...)
+func (c *Config) SetCallbackURL(url string) {
+	c.RedirectURI = url
+}
+
+func (c *Config) Build() goth.Provider {
+	provider := New(c.ClientID, c.ClientSecret, c.RedirectURI, c.Duration, c.TokenEndpoint, c.UserURL, c.Scopes...)
+	return &provider
 }
 
 func New(clientID string, clientSecret string, redirectURI string, duration string, tokenEndpoint string, userURL string, scopes ...string) Provider {

--- a/providers/reddit/reddit.go
+++ b/providers/reddit/reddit.go
@@ -34,6 +34,10 @@ type Config struct {
 	Scopes        []string
 }
 
+func (c *Config) Name() string {
+	return "reddit"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.RedirectURI = url
 }

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -45,6 +45,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "salesforce"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -45,7 +45,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/salesforce/salesforce.go
+++ b/providers/salesforce/salesforce.go
@@ -38,6 +38,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Salesforce provider and sets up important connection details.
 // You should always call `salesforce.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/seatalk/seatalk.go
+++ b/providers/seatalk/seatalk.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new SeaTalk provider and sets up important connection details.
 // You should always call `seatalk.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/seatalk/seatalk.go
+++ b/providers/seatalk/seatalk.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/seatalk/seatalk.go
+++ b/providers/seatalk/seatalk.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "seatalk"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/shopify/shopify.go
+++ b/providers/shopify/shopify.go
@@ -42,6 +42,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "shopify"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/shopify/shopify.go
+++ b/providers/shopify/shopify.go
@@ -35,6 +35,17 @@ type Provider struct {
 	scopes       []string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Shopify provider and sets up important connection details.
 // You should always call `shopify.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/shopify/shopify.go
+++ b/providers/shopify/shopify.go
@@ -42,7 +42,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -36,6 +36,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Slack provider and sets up important connection details.
 // You should always call `slack.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -43,6 +43,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "slack"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/slack/slack.go
+++ b/providers/slack/slack.go
@@ -43,7 +43,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -38,6 +38,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "soundcloud"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -31,6 +31,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Soundcloud provider and sets up important connection details.
 // You should always call `soundcloud.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -38,7 +38,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -101,7 +101,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -101,6 +101,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "spotify"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -94,6 +94,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name gets the name used to retrieve this provider.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -48,6 +48,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "steam"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -43,6 +43,15 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ApiKey      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ApiKey, c.CallbackURL)
+}
+
 // Name gets the name used to retrieve this provider.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -48,7 +48,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ApiKey, c.CallbackURL)
 }
 

--- a/providers/strava/strava.go
+++ b/providers/strava/strava.go
@@ -52,7 +52,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/strava/strava.go
+++ b/providers/strava/strava.go
@@ -45,6 +45,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/strava/strava.go
+++ b/providers/strava/strava.go
@@ -52,6 +52,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "strava"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -28,6 +28,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Stripe provider and sets up important connection details.
 // You should always call `stripe.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -35,7 +35,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/stripe/stripe.go
+++ b/providers/stripe/stripe.go
@@ -35,6 +35,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "stripe"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/tiktok/tiktok.go
+++ b/providers/tiktok/tiktok.go
@@ -38,6 +38,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new TikTok provider, and sets up connection details.
 func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 	p := &Provider{

--- a/providers/tiktok/tiktok.go
+++ b/providers/tiktok/tiktok.go
@@ -45,7 +45,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/tiktok/tiktok.go
+++ b/providers/tiktok/tiktok.go
@@ -45,6 +45,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "tiktok"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/tumblr/tumblr.go
+++ b/providers/tumblr/tumblr.go
@@ -61,6 +61,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "tumblr"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/tumblr/tumblr.go
+++ b/providers/tumblr/tumblr.go
@@ -61,7 +61,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL)
 }
 

--- a/providers/tumblr/tumblr.go
+++ b/providers/tumblr/tumblr.go
@@ -55,6 +55,16 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -242,7 +242,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -235,6 +235,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name gets the name used to retrieve this provider.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/twitch/twitch.go
+++ b/providers/twitch/twitch.go
@@ -242,6 +242,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "twitch"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -69,6 +69,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "twitter"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -69,7 +69,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL)
 }
 

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -63,6 +63,16 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -69,6 +69,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "twitterv2"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -69,7 +69,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL)
 }
 

--- a/providers/twitterv2/twitterv2.go
+++ b/providers/twitterv2/twitterv2.go
@@ -63,6 +63,16 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/typetalk/typetalk.go
+++ b/providers/typetalk/typetalk.go
@@ -34,6 +34,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Typetalk provider and sets up important connection details.
 // You should always call `typetalk.New` to get a new provider. Never try to
 // create one manually.

--- a/providers/typetalk/typetalk.go
+++ b/providers/typetalk/typetalk.go
@@ -41,7 +41,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/typetalk/typetalk.go
+++ b/providers/typetalk/typetalk.go
@@ -41,6 +41,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "typetalk"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -35,6 +35,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "uber"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -35,7 +35,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/uber/uber.go
+++ b/providers/uber/uber.go
@@ -28,6 +28,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Uber provider and sets up important connection details.
 // You should always call `uber.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/vk/vk.go
+++ b/providers/vk/vk.go
@@ -54,6 +54,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "vk"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/vk/vk.go
+++ b/providers/vk/vk.go
@@ -47,6 +47,17 @@ type Provider struct {
 	version      string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/vk/vk.go
+++ b/providers/vk/vk.go
@@ -54,7 +54,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/wechat/wechat.go
+++ b/providers/wechat/wechat.go
@@ -42,6 +42,10 @@ type Config struct {
 	Lang         WechatLangType
 }
 
+func (c *Config) Name() string {
+	return "wechat"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.RedirectURL = url
 }

--- a/providers/wechat/wechat.go
+++ b/providers/wechat/wechat.go
@@ -42,7 +42,11 @@ type Config struct {
 	Lang         WechatLangType
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.RedirectURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientID, c.ClientSecret, c.RedirectURL, c.Lang)
 }
 

--- a/providers/wechat/wechat.go
+++ b/providers/wechat/wechat.go
@@ -35,6 +35,17 @@ type Provider struct {
 	ProfileURL string
 }
 
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	Lang         WechatLangType
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientID, c.ClientSecret, c.RedirectURL, c.Lang)
+}
+
 type WechatLangType string
 
 const (

--- a/providers/wecom/wecom.go
+++ b/providers/wecom/wecom.go
@@ -56,6 +56,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "wecom"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/wecom/wecom.go
+++ b/providers/wecom/wecom.go
@@ -56,7 +56,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.CorpID, c.Secret, c.AgentID, c.CallbackURL)
 }
 

--- a/providers/wecom/wecom.go
+++ b/providers/wecom/wecom.go
@@ -49,6 +49,17 @@ type Provider struct {
 	baseURL string
 }
 
+type Config struct {
+	CorpID      string
+	Secret      string
+	AgentID     string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.CorpID, c.Secret, c.AgentID, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Wepay provider and sets up important connection details.
 // You should always call `wepay.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "wepay"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/wepay/wepay.go
+++ b/providers/wepay/wepay.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/xero/xero.go
+++ b/providers/xero/xero.go
@@ -99,6 +99,10 @@ type Config struct {
 	CallbackURL string
 }
 
+func (c *Config) Name() string {
+	return "xero"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/xero/xero.go
+++ b/providers/xero/xero.go
@@ -93,6 +93,16 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL)
+}
+
 // Name is the name used to retrieve this provider later.
 func (p *Provider) Name() string {
 	return p.providerName

--- a/providers/xero/xero.go
+++ b/providers/xero/xero.go
@@ -99,7 +99,11 @@ type Config struct {
 	CallbackURL string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL)
 }
 

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -35,6 +35,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "yahoo"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -28,6 +28,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Yahoo provider and sets up important connection details.
 // You should always call `yahoo.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -35,7 +35,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -31,6 +31,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Yammer provider and sets up important connection details.
 // You should always call `yammer.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -38,6 +38,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "yammer"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/yammer/yammer.go
+++ b/providers/yammer/yammer.go
@@ -38,7 +38,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/yandex/yandex.go
+++ b/providers/yandex/yandex.go
@@ -31,6 +31,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 // New creates a new Yandex provider and sets up important connection details.
 // You should always call `yandex.New` to get a new provider.  Never try to
 // create one manually.

--- a/providers/yandex/yandex.go
+++ b/providers/yandex/yandex.go
@@ -38,7 +38,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 

--- a/providers/yandex/yandex.go
+++ b/providers/yandex/yandex.go
@@ -38,6 +38,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "yandex"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/zoom/zoom.go
+++ b/providers/zoom/zoom.go
@@ -30,6 +30,17 @@ type Provider struct {
 	providerName string
 }
 
+type Config struct {
+	ClientKey   string
+	Secret      string
+	CallbackURL string
+	Scopes      []string
+}
+
+func (c Config) Build() *Provider {
+	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
+}
+
 type profileResp struct {
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`

--- a/providers/zoom/zoom.go
+++ b/providers/zoom/zoom.go
@@ -37,6 +37,10 @@ type Config struct {
 	Scopes      []string
 }
 
+func (c *Config) Name() string {
+	return "zoom"
+}
+
 func (c *Config) SetCallbackURL(url string) {
 	c.CallbackURL = url
 }

--- a/providers/zoom/zoom.go
+++ b/providers/zoom/zoom.go
@@ -37,7 +37,11 @@ type Config struct {
 	Scopes      []string
 }
 
-func (c Config) Build() *Provider {
+func (c *Config) SetCallbackURL(url string) {
+	c.CallbackURL = url
+}
+
+func (c *Config) Build() goth.Provider {
 	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
 }
 


### PR DESCRIPTION
This PR introduces `ProviderConfig` interface that allows to separate Provider configuration from Provider creation. 

**Why?**
Primarly because Provider's `New` methods require to set `CallbackURL` at creation time. At complex Routers this might be set programmatically but Provider has `CallbackURL` unmutable after its creation. `goth` contains all the Providers in separate package so my decision here was to create a `ProviderConfig` interface and `Config` struct for all the providers, that will contain `New` method's params and will produce the corresponding `Provider` via `ProviderConfig.Build()`.

The interface includes 3 methods:

1. `Name() string` - returns the default Config's Provider name
2. `SetCallbackURL(string)` - allows to set URL (all Providers have it)
3. `Build() Provider` - runs `New` method passing Config data as params

```go
type ProviderConfig interface {
	Name() string
	SetCallbackURL(string)
	Build() Provider
}
```

Here's how it looks for the Google Provider:
```go
type Provider struct {
	ClientKey       string
	Secret          string
	CallbackURL     string
	HTTPClient      *http.Client
	config          *oauth2.Config
	authCodeOptions []oauth2.AuthCodeOption
	providerName    string
}

type Config struct {
	ClientKey   string
	Secret      string
	CallbackURL string
	Scopes      []string
}

func (c *Config) Name() string {
	return "google"
}

func (c *Config) SetCallbackURL(url string) {
	c.CallbackURL = url
}

func (c *Config) Build() goth.Provider {
	return New(c.ClientKey, c.Secret, c.CallbackURL, c.Scopes...)
}

// Name is the name used to retrieve this provider later.
func (p *Provider) Name() string {
	return p.providerName
}

func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
	// ...
}
```

What it allows to do - provide only configs at init time:
```go
configs := []goth.ProviderConfig{
		&azureadv2.Config{
			ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
			Secret:    "foo",
		},
		&github.Config{
			ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
			Secret:    "foo",
		},
		&tiktok.Config{
			ClientKey: "6731de76-14a6-49ae-97bc-6eba6914391e",
			Secret:    "foo",
		},
		&apple.Config{
			ClientId: "6731de76-14a6-49ae-97bc-6eba6914391e",
			Secret:   "foo",
		},
	}
```
and build Providers later, let's say somewhere in oauth module:
```go
func (oa *OAuthAuthenticator) Mount(mux *http.ServeMux, prefix string, errHandler tools.ErrorHandler) {
	providers := make([]goth.Provider, len(oa.providerConfigs))
	for i, cfg := range oa.providerConfigs {
		cfg.SetCallbackURL(oa.baseDomain + prefix + "/" + cfg.Name() + "/callback")
		providers[i] = cfg.Build()
	}
	goth.UseProviders(providers...)
	mux.Handle("GET "+prefix+"/{provider}", errHandler(tools.HandlerFunc(oa.AuthHandler)))
	mux.Handle("GET "+prefix+"/{provider}/callback", errHandler(tools.HandlerFunc(oa.CallbackHandler)))
	mux.Handle("POST "+prefix+"/logout", errHandler(tools.HandlerFunc(oa.LogoutHandler)))
}
```

I made a generalized test in `provider_test.go`. Probably can cover more providers and cases it you find it an interesting feature to add to original `goth` package.